### PR TITLE
Removed sudo from docker-entrypoint.sh

### DIFF
--- a/extras/docker/docker-entrypoint.sh
+++ b/extras/docker/docker-entrypoint.sh
@@ -11,4 +11,4 @@ done
 # Check if database is created, migrated and seeded
 node extras/docker/config_database.js
 
-sudo DATABASE_HOST=$DATABASE_HOST npm start
+npm start


### PR DESCRIPTION
Doing 'sudo' when 'npm start' in the entry point does not make sense as:
1.- User is already root
2.- sudo doesn't preserve environment variables by default, which makes difficult to configure the container through .env files for example. 

Removing sudo command also makes DATABASE_HOST env variable definition not necessary anymore.