### PR TITLE
Always return 401 to any auth/tokens failure

### DIFF
--- a/controllers/api/authenticate.js
+++ b/controllers/api/authenticate.js
@@ -103,10 +103,11 @@ var info_token = function(req, res, next) {
 	}).then(function(token) {
 		res.status(200).json(token)
 	}).catch(function(error) {
+		// Log the actual error to the debug log
 		debug('Error: ' + error)
-		if (!error.error) {
-			error = { error: {message: 'Internal error', code: 500, title: 'Internal error'}}
-		}
+		// Always return the same 401 - Unauthorized error to the user.
+		// This avoids information leakage.
+		error = { error: {message: 'Invalid email or password', code: 401, title: 'Unauthorized'}}
 		res.status(error.error.code).json(error)
 	})
 }

--- a/controllers/api/authenticate.js
+++ b/controllers/api/authenticate.js
@@ -107,7 +107,9 @@ var info_token = function(req, res, next) {
 		debug('Error: ' + error)
 		// Always return the same 401 - Unauthorized error to the user.
 		// This avoids information leakage.
-		error = { error: {message: 'Invalid email or password', code: 401, title: 'Unauthorized'}}
+		if (!error.error || error.error.code !== 401){
+			error = { error: {message: 'Invalid email or password', code: 401, title: 'Unauthorized'}}
+		}
 		res.status(error.error.code).json(error)
 	})
 }
@@ -253,9 +255,13 @@ var create_token = function(req, res, next) {
 		})
 
 	}).catch(function(error) {
+		// Log the actual error to the debug log
 		debug('Error: ' + error)
-		if (!error.error) {
-			error = { error: {message: 'Internal error', code: 500, title: 'Internal error'}}
+		// If an actual 401 has been raised, use the existing message.
+		// But always return a 401 - Unauthorized error to the user.
+		// This avoid information leakage. 
+		if (!error.error || error.error.code !== 401){
+			error = { error: {message: 'Invalid email or password', code: 401, title: 'Unauthorized'}}
 		}
 		res.status(error.error.code).json(error)
 	})


### PR DESCRIPTION
When challenging for Username/Password, the error response should always be the same to avoid leaking additional information.

If I return 404 if the user is not found or 500 if a server error occurs, I would be sending unnecessary extra information back to an unauthenticated user.

This change logs the real error, but always sends back a 401 - Unauthorised in the event of failure.