### PR TITLE
Idempotent  Update endpoints should use PUT

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1484,7 +1484,7 @@ Applications are registered in Keyrock and consume OAuth2 resources.
     + application_id - Id of the application.
     + role_id - Id of the role.
 
-### Assign a role to a user [POST]
+### Assign a role to a user [PUT]
 + Request (application/json)
     + Headers
         
@@ -1626,7 +1626,7 @@ Applications are registered in Keyrock and consume OAuth2 resources.
     + role_id - Id of the role.
     + organization_role_id - Id of organization role.
 
-### Assign a role to a organization [POST]
+### Assign a role to a organization [PUT]
 + Request (application/json)
     + Headers
         
@@ -1744,7 +1744,7 @@ Applications are registered in Keyrock and consume OAuth2 resources.
     + user_id - Id of the user.
     + organization_role_id - Id of the organization role.
 
-### Create relationship [POST]        
+### Create relationship [PUT]        
 + Request (application/json)
     + Headers
         

--- a/controllers/api/role_organization_assignments.js
+++ b/controllers/api/role_organization_assignments.js
@@ -57,10 +57,10 @@ exports.index_organization_roles = function(req, res) {
 	})
 }
 
-// POST /v1/applications/:applicationId/organizations/:organizationId/roles/:roleId/organization_roles/organizationRoleId -- Edit role organization assignment
-exports.create = function(req, res) {
+// PUT /v1/applications/:applicationId/organizations/:organizationId/roles/:roleId/organization_roles/organizationRoleId -- Add role organization assignment
+exports.addRole = function(req, res) {
 
-	debug('--> create')
+	debug('--> addRole')
 
 	if (req.changeable_role) {
 		var changeable_role_id = req.changeable_role.map(elem => elem.id)
@@ -92,9 +92,9 @@ exports.create = function(req, res) {
 }
 
 // DELETE /v1/applications/:applicationId/organizations/:organizationId/roles/:roleId/organization_roles/organizationRoleId -- Remove role organization assignment
-exports.delete = function(req, res) {
+exports.removeRole = function(req, res) {
 
-	debug('--> delete')
+	debug('--> removeRole')
 
 	if (req.changeable_role) {
 		var changeable_role_id = req.changeable_role.map(elem => elem.id)

--- a/controllers/api/role_user_assignments.js
+++ b/controllers/api/role_user_assignments.js
@@ -71,10 +71,10 @@ exports.index_user_roles = function(req, res) {
 	})
 }
 
-// POST /v1/applications/:applicationId/users/:user_id/roles/:role_id -- Edit role user assignment
-exports.create = function(req, res) {
+// PUT /v1/applications/:applicationId/users/:user_id/roles/:role_id -- Add role user assignment
+exports.addRole = function(req, res) {
 
-	debug('--> create')
+	debug('--> addRole')
 
 	if (req.changeable_role) {
 		var changeable_role_id = req.changeable_role.map(elem => elem.id)
@@ -102,9 +102,9 @@ exports.create = function(req, res) {
 }
 
 // DELETE /v1/applications/:applicationId/users/:user_id/roles/:role_id -- Remove role user assignment
-exports.delete = function(req, res) {
+exports.removeRole = function(req, res) {
 
-	debug('--> delete')
+	debug('--> removeRole')
 
 	if (req.changeable_role) {
 		var changeable_role_id = req.changeable_role.map(elem => elem.id)

--- a/controllers/api/user_organization_assignments.js
+++ b/controllers/api/user_organization_assignments.js
@@ -45,9 +45,9 @@ exports.info = function(req, res) {
 	})
 }
 
-// POST /v1/organizations/:organizationId/users/:userId/:organizationRoleId -- Edit user organization assignment
-exports.create = function(req, res) {
-	debug('--> create')
+// PUT /v1/organizations/:organizationId/users/:userId/:organizationRoleId -- Set user organization assignment
+exports.setRole = function(req, res) {
+	debug('--> setRole')
 
 	models.user_organization.findOne({
 		where: { organization_id: req.organization.id, 
@@ -75,8 +75,8 @@ exports.create = function(req, res) {
 }
 
 // DELETE /v1/user_organization_assignments/:user_id/organizations/:organization_id -- Remove user organization assignment
-exports.delete = function(req, res) {
-	debug('--> delete')
+exports.removeRole = function(req, res) {
+	debug('--> removeRole')
 	
 	models.user_organization.destroy({
 		where: { role: req.role_organization, user_id: req.user.id, organization_id: req.organization.id }

--- a/routes/api/applications.js
+++ b/routes/api/applications.js
@@ -71,14 +71,19 @@ router.delete('/:applicationId/roles/:roleId/permissions/:permissionId', 	api_ro
 // Routes for role_user_assignments
 router.get('/:applicationId/users', 							api_role_controller.search_changeable_roles,	api_role_user_assign_controller.index_users);
 router.get('/:applicationId/users/:userId/roles', 				api_role_controller.search_changeable_roles,	api_role_user_assign_controller.index_user_roles);
-router.post('/:applicationId/users/:userId/roles/:roleId', 		api_role_controller.search_changeable_roles,	api_role_user_assign_controller.create);
-router.delete('/:applicationId/users/:userId/roles/:roleId', 	api_role_controller.search_changeable_roles,	api_role_user_assign_controller.delete);
+router.put('/:applicationId/users/:userId/roles/:roleId', 		api_role_controller.search_changeable_roles,	api_role_user_assign_controller.addRole);
+router.delete('/:applicationId/users/:userId/roles/:roleId', 	api_role_controller.search_changeable_roles,	api_role_user_assign_controller.removeRole);
+// POST endpoint is deprecated - maintained for backwards compatibility
+router.post('/:applicationId/users/:userId/roles/:roleId', 		api_role_controller.search_changeable_roles,	api_role_user_assign_controller.addRole);
 
 // Routes for role_organization_assignments
 router.get('/:applicationId/organizations', 																		api_role_controller.search_changeable_roles,	api_role_org_assign_controller.index_organizations);
 router.get('/:applicationId/organizations/:organizationId/roles', 													api_role_controller.search_changeable_roles,	api_role_org_assign_controller.index_organization_roles);
-router.post('/:applicationId/organizations/:organizationId/roles/:roleId/organization_roles/:organizationRoleId', 	api_role_controller.search_changeable_roles,	api_role_org_assign_controller.create);
-router.delete('/:applicationId/organizations/:organizationId/roles/:roleId/organization_roles/:organizationRoleId', api_role_controller.search_changeable_roles,	api_role_org_assign_controller.delete);
+router.put('/:applicationId/organizations/:organizationId/roles/:roleId/organization_roles/:organizationRoleId', 	api_role_controller.search_changeable_roles,	api_role_org_assign_controller.addRole);
+router.delete('/:applicationId/organizations/:organizationId/roles/:roleId/organization_roles/:organizationRoleId', api_role_controller.search_changeable_roles,	api_role_org_assign_controller.removeRole);
+// POST endpoint is deprecated - maintained for backwards compatibility
+router.post('/:applicationId/organizations/:organizationId/roles/:roleId/organization_roles/:organizationRoleId', 	api_role_controller.search_changeable_roles,	api_role_org_assign_controller.addRole);
+
 
 // Routes for trusted applications
 router.get('/:applicationId/trusted_applications', 							api_trusted_app_controller.index);

--- a/routes/api/user_organization_assignments.js
+++ b/routes/api/user_organization_assignments.js
@@ -10,7 +10,9 @@ router.param('organizationRoleId',   require('../../controllers/api/index').orga
 // Routes for user_organization_assignments
 router.get('/', 							api_user_org_assign_controller.index);
 router.get('/:userId/organization_roles', 						api_user_org_assign_controller.info);
-router.post('/:userId/organization_roles/:organizationRoleId', 		api_user_org_assign_controller.create);
-router.delete('/:userId/organization_roles/:organizationRoleId', 	api_user_org_assign_controller.delete);
+router.put('/:userId/organization_roles/:organizationRoleId', 		api_user_org_assign_controller.addRole);
+router.delete('/:userId/organization_roles/:organizationRoleId', 	api_user_org_assign_controller.removeRole);
+// POST endpoint is deprecated - maintained for backwards compatibility
+router.post('/:userId/organization_roles/:organizationRoleId', 		api_user_org_assign_controller.addRole);
 
 module.exports = router;


### PR DESCRIPTION
The following endpoints are idempotent:

- Assigning a Users to an organisation
- Adding Roles to Users within an Application
- Adding Roles to organisation within an Application

However each is currently invoked using a POST request- I believe this is incorrect as POST does not maintain idempotency whereas PUT does - in other words if I try to add a user to a role multiple times the result is that only one association is created.

Switching these endpoints from POST to PUT will make the API syntactically correct and easier to understand. The equivalent POST  endpoints can also maintained (for backwards compatibility) but should be deprecated.