### PR TITLE
Add missing X-Auth tokens

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1514,6 +1514,11 @@ Applications are registered in Keyrock and consume OAuth2 resources.
 
 ### Remove a role assignment from a user [DELETE]
 
++ Request
+    + Headers
+        
+            X-Auth-token: token
+
 + Response 204
 
 
@@ -1657,6 +1662,11 @@ Applications are registered in Keyrock and consume OAuth2 resources.
 
 
 ### Remove a role assignment from an organization [DELETE]
+
++ Request
+    + Headers
+        
+            X-Auth-token: token
 
 + Response 204
 


### PR DESCRIPTION
This fixes a minor bug in the apiary file.

- X-Auth tokens are mandatory when deleting relationships