### PR TITLE
Correctly process boolean values

### DIFF
--- a/extras/docker/config.js.template
+++ b/extras/docker/config.js.template
@@ -1,12 +1,16 @@
 var config = {};
 
+function toBoolean(env, defaultValue){
+    return (env !== undefined) ? (env.toLowerCase() === 'true') : defaultValue;
+}
+
 config.port = (process.env.IDM_PORT || 3000 );
 config.host = (process.env.IDM_HOST || 'http://localhost:' + config.port);
 
 
 // HTTPS enable
 config.https = {
-    enabled: (process.env.IDM_HTTPS_ENABLED || false),
+    enabled: toBoolean(process.env.IDM_HTTPS_ENABLED, false),
     cert_file: 'certs/idm-2018-cert.pem',
     key_file: 'certs/idm-2018-key.pem',
     ca_certs: [],
@@ -48,7 +52,7 @@ config.api = {
 config.authorization = {
     level: (process.env.IDM_PDP_LEVEL || 'basic'),     // basic|advanced 
     authzforce: {
-        enabled: (process.env.IDM_AUTHZFORCE_ENABLED || false),
+        enabled: toBoolean(process.env.IDM_AUTHZFORCE_ENABLED, false),
         host: (process.env.IDM_AUTHZFORCE_HOST || 'localhost'),
         port: (process.env.IDM_AUTHZFORCE_PORT||  8080),
     } 
@@ -67,7 +71,7 @@ config.database  = {
 };
 // External user authentication
 config.external_auth = {
-    enabled: (process.env.IDM_EX_AUTH_ENABLED || false ),
+    enabled: toBoolean(process.env.IDM_EX_AUTH_ENABLED, false),
     authentication_driver: (process.env.IDM_EX_AUTH_DRIVER ||'custom_authentication_driver'),
     database: {
         host: (process.env.IDM_EX_AUTH_DB_HOST ||'localhost'),
@@ -95,7 +99,7 @@ config.site = {
 
 // Config eIDAs Authentication
 config.eidas = {
-    enabled:       (process.env.IDM_EIDAS_ENABLED || false),
+    enabled:       toBoolean(process.env.IDM_EIDAS_ENABLED, false),
     gateway_host:  (process.env.IDM_EIDAS_GATEWAY_HOST || 'localhost'),
     idp_host:      (process.env.IDM_EIDAS_IDP_HOST || 'https://se-eidas.redsara.es/EidasNode/ServiceProvider'),
     metadata_expiration: 60 * 60 * 24 * 365 // One year


### PR DESCRIPTION
When using docker compose, `true` and `false` are processed as strings - amend config to load these as booleans with appropriate default values.