### PR TITLE
Permissions are now matching any actual URL that starts with the perm…

### DIFF
--- a/models/model_oauth_server.js
+++ b/models/model_oauth_server.js
@@ -623,10 +623,12 @@ function user_permissions(roles_id, app_id, action, resource) {
         if (permissions.length > 0) {
             return models.permission.findAll({
                 where: { id: permissions.map(elem => elem.permission_id),
-                         oauth_client_id: app_id,
-                         action: action,
-                         resource: resource }
+                    oauth_client_id: app_id,
+                    action: action,
+                }
             })
+                .then(permissions =>
+                    permissions.filter(permission => resource.startsWith(permission.dataValues.resource)))
         } else {
             return []
         }


### PR DESCRIPTION
Idm supports basic authorization. With this update its authorization capabilities are extended, since URLs in permissions are basically treaded as patterns.
E.g. 
Permission POST + /v2/entities allows to create any entity
Permission GET + /v2/entities, however, does not allow anything, since every GET request needs the entities Id as a path parameter (e.g. GET + /v2/entities/Room1). Thus currently there's no way to allow an admin user to read all entities.

This patch treads every URL like a "startsWith" pattern:
Consequently, permission GET + /v2/entities works like GET + /v2/entities* and matches also /v2/entities/Room1 (and basically allows to read any entity).

This will be of great value in practical applications of IDM-based authorization without compromising its security.
