### PR TITLE
Fix #50 - Amend Authzforce  Accept Header

### DIFF
--- a/lib/authzforce.js
+++ b/lib/authzforce.js
@@ -5,6 +5,7 @@ var http = require('http');
 var Promise = require('bluebird');
 var uuid = require('uuid');
 var config = require ('../config.js').authorization.authzforce;
+var debug = require('debug')('idm:authzforce');
 
 // Handle domain and policy creation
 exports.handle = function(domain, role_permissions) {
@@ -27,6 +28,7 @@ exports.handle = function(domain, role_permissions) {
 
 // Function to get authzforce domain of application
 function get_application_domain(domain) {
+	debug("--> get_application_domain")
 	return new Promise(function(resolve, reject) {
 		// See if application has an authzforce domain assigned, if not create it
 		if (!domain.az_domain) {
@@ -90,6 +92,7 @@ function get_application_domain(domain) {
 
 // Function to create policy of application
 function policy_set_update(application_id, az_domain, policy_version, policy, role_permissions) {
+	debug("--> policy_set_update")
 	return new Promise(function(resolve, reject) {
 
 		// Info to set in template
@@ -112,8 +115,8 @@ function policy_set_update(application_id, az_domain, policy_version, policy, ro
 
 				// Set headers
 		        var headers = {
-				    'Accept': 'application/xml; charset=UTF-8',
-				    'Content-Type': 'application/xml; charset=UTF-8', 
+				    'Accept': 'application/xml',
+				    'Content-Type': 'application/xml; charset=utf-8', 
 				};
 
 				// Set host and port from config file
@@ -133,7 +136,7 @@ function policy_set_update(application_id, az_domain, policy_version, policy, ro
 
 		        // Check error in request
 				req.on('error', function(e) {
-				  	reject('Create policy: connection with authzforce failed')
+				  	reject('Create policy: connection with authzforce failed' + e)
 				});
 
 				// Set body of request with the filled template
@@ -148,6 +151,7 @@ function policy_set_update(application_id, az_domain, policy_version, policy, ro
 
 // Function to activate policy of application
 function activate_policy(az_domain, policy, version_policy) {
+	debug("--> activate_policy")
 	return new Promise(function(resolve, reject) {
 
 		ejs.renderFile(__dirname + '/../lib/authzforce_templates/policy_properties.ejs', {'policy_id': policy }, function(error, body) {
@@ -155,8 +159,8 @@ function activate_policy(az_domain, policy, version_policy) {
 
 				// Set headers
 		        var headers = {
-				    'Accept': 'application/xml; charset=UTF-8',
-				    'Content-Type': 'application/xml; charset=UTF-8', 
+				    'Accept': 'application/xml',
+				    'Content-Type': 'application/xml; charset=utf-8', 
 				};
 
 				// Set host and port from config file
@@ -176,13 +180,14 @@ function activate_policy(az_domain, policy, version_policy) {
 
 		        // Check error in request
 				req.on('error', function(e) {
-				  	reject('Activate policy: connection with authzforce failed')
+				  	reject('Activate policy: connection with authzforce failed' + e)
 				});
 
 				// Set body of request with the filled template
 				req.write(body);
 				req.end();
 			} else {
+
 				reject(error)
 			}
 		});
@@ -191,6 +196,7 @@ function activate_policy(az_domain, policy, version_policy) {
 
 // Function to check connection with authzforce 
 exports.check_connection = function() {
+	debug("--> check_connection")
 
 	return new Promise(function(resolve, reject) {
 		// Set host and port from config file


### PR DESCRIPTION
* Amend Authzforce  Accept Header
* Add function debug

The `Accept` header should not include a `charset` requirement, it should only remain on the `Content-Type`
Authzforce is interpreting the header very strictly and is correctly returning a 406 error.

Compare the following:

* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type