### PR TITLE
Fix #52 - Remove salt from calls to verify password.

### DIFF
--- a/controllers/api/pep_proxies.js
+++ b/controllers/api/pep_proxies.js
@@ -16,7 +16,7 @@ exports.authenticate = function(id, password, callback) {
     }).then(function(pep_proxy) {
         if (pep_proxy) {
             // Verify password 
-            if(pep_proxy.verifyPassword(pep_proxy.salt, password)){
+            if(pep_proxy.verifyPassword(password)){
                 callback(null, pep_proxy);
             } else { callback(new Error('invalid')); }   
         } else { callback(new Error('pep_proxy_not_found')); }

--- a/controllers/web/pep_proxies.js
+++ b/controllers/web/pep_proxies.js
@@ -140,7 +140,7 @@ exports.authenticate = function(id, password, callback) {
     }).then(function(pep_proxy) {
         if (pep_proxy) {
             // Verify password 
-            if(pep_proxy.verifyPassword(pep_proxy.salt, password)){
+            if(pep_proxy.verifyPassword(password)){
                 callback(null, pep_proxy);
             } else { callback(new Error('invalid')); }   
         } else { callback(new Error('pep_proxy_not_found')); }

--- a/controllers/web/settings.js
+++ b/controllers/web/settings.js
@@ -54,7 +54,7 @@ exports.password = function(req, res) {
 	    }).then(function(user) {
 	        if (user) {
 	            // Verify password and if user is enabled to use the web
-	            if(user.verifyPassword(user.salt, req.body.current_password)) {
+	            if(user.verifyPassword(req.body.current_password)) {
 
 	            	models.user.update({ 
 	            		password: req.body.new_password,
@@ -135,7 +135,7 @@ exports.email = function(req, res) {
 			    }).then(function(user) {
 			        if (user) {
 			            // Verify password and if user is enabled to use the web
-			            if(user.verifyPassword(user.salt, req.body.password)) {	      
+			            if(user.verifyPassword(req.body.password)) {	      
 
 			           		var verification_key = Math.random().toString(36).substr(2);
 			                var verification_expires = new Date((new Date()).getTime() + 1000*3600*24)

--- a/models/iot.js
+++ b/models/iot.js
@@ -34,8 +34,8 @@ module.exports = function(sequelize, DataTypes) {
       underscored: true
   });
 
-  Iot.prototype.verifyPassword = function(salt, password) {
-    var encripted = crypto.createHmac('sha1', (salt) ? salt : key).update(password).digest('hex');
+  Iot.prototype.verifyPassword = function(password) {
+    var encripted = crypto.createHmac('sha1', this.salt ? this.salt : key).update(password).digest('hex');
     return encripted === this.password;
   }
 

--- a/models/model_oauth_server.js
+++ b/models/model_oauth_server.js
@@ -122,14 +122,14 @@ function getIdentity(id, password) {
     }
 
     if (user) {
-      if (user.verifyPassword(user.salt, password)) {
+      if (user.verifyPassword(password)) {
           user.dataValues["type"] = "user"
           return user
       } 
     }
 
     if (iot) {
-      if (iot.verifyPassword(iot.salt, password)) {
+      if (iot.verifyPassword(password)) {
           iot.dataValues["type"] = "iot"
           return iot
       } 
@@ -154,7 +154,7 @@ function getUser(email, password) {
     })
     .then(function (user) {
       if (user) {
-        if (user.verifyPassword(user.salt, password)) {
+        if (user.verifyPassword(password)) {
           return user.toJSON()
         } 
       }

--- a/models/pep_proxy.js
+++ b/models/pep_proxy.js
@@ -34,8 +34,8 @@ module.exports = function(sequelize, DataTypes) {
       underscored: true
   });
 
-  PepProxy.prototype.verifyPassword = function(salt, password) {
-    var encripted = crypto.createHmac('sha1', (salt) ? salt : key).update(password).digest('hex');
+  PepProxy.prototype.verifyPassword = function(password) {
+    var encripted = crypto.createHmac('sha1', this.salt ? this.salt : key).update(password).digest('hex');
     return encripted === this.password;
   }
 

--- a/models/user.js
+++ b/models/user.js
@@ -95,7 +95,7 @@ module.exports = function(sequelize, DataTypes) {
     );
 
     User.prototype.verifyPassword = function(password) {
-        var encripted = crypto.createHmac('sha1', (this.salt) ? this.salt : key).update(password).digest('hex');
+        var encripted = crypto.createHmac('sha1', this.salt ? this.salt : key).update(password).digest('hex');
         return encripted === this.password;
     }   
         


### PR DESCRIPTION
* The `salt` already exists within the User/PepProxy/IoT object and does not need to be passed
* Amend all `verifyPassword()` calls to pass a single parameter