### PR TITLE
Suppress Saas debug from log.

### DIFF
--- a/app.js
+++ b/app.js
@@ -65,7 +65,7 @@ var styles = config.site.theme || 'default';
 app.use(sassMiddleware({
     src: path.join(__dirname, 'themes/' + styles),
     dest: path.join(__dirname, 'public/stylesheets'),
-    debug: true,
+    debug: false,
     // outputStyle: 'compressed',
     outputStyle: 'extended',
     prefix:  '/stylesheets'  // Where prefix is at <link rel="stylesheets" href="prefix/style.css"/>


### PR DESCRIPTION
When running with `DEBUG` output, the Saas debug is very verbose - it writes half-a-dozen lines with every page load and basically irrelevant to users.

This PR adds a switch to remove the saas debug from the log. 