### PR TITLE
Update Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules/
+doc/
+npm-debug.log

--- a/extras/docker/Dockerfile
+++ b/extras/docker/Dockerfile
@@ -1,4 +1,12 @@
-FROM ubuntu:16.04
+ARG NODE_VERSION=8.12.0-slim
+FROM node:${NODE_VERSION}
+ARG GITHUB_ACCOUNT=ging
+ARG GITHUB_REPOSITORY=fiware-idm
+ARG DOWNLOAD_TYPE=latest
+
+ENV GITHUB_ACCOUNT=${GITHUB_ACCOUNT}
+ENV GITHUB_REPOSITORY=${GITHUB_REPOSITORY}
+ENV DOWNLOAD_TYPE=${DOWNLOAD_TYPE}
 
 MAINTAINER FIWARE Identity Manager Team. DIT-UPM
 
@@ -43,47 +51,59 @@ ENV IDM_HOST "http://localhost:3000" \
 # ENV IDM_EX_AUTH_DIALECT "mysql"
 
 
-# Install Ubuntu dependencies
+# Install Ubuntu dependencies & email dependency & Configure mail
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends build-essential debconf-utils ca-certificates curl git netcat  && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# Install email dependency
-RUN apt-get update && \
-    echo "postfix postfix/mailname string noreply@localhost" | debconf-set-selections && \
+    apt-get install -y --no-install-recommends build-essential python debconf-utils curl git netcat  && \
+    echo "postfix postfix/mailname string ${IDM_EMAIL_ADDRESS}" | debconf-set-selections && \
     echo "postfix postfix/main_mailer_type string 'Internet Site'" | debconf-set-selections && \
-    apt-get install -y --no-install-recommends  mailutils && \
+    apt-get install -y --no-install-recommends postfix mailutils && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    sed -i 's/inet_interfaces = all/inet_interfaces = loopback-only/g' /etc/postfix/main.cf
 
 
-# Configure mail
-RUN sed -i 's/inet_interfaces = all/inet_interfaces = loopback-only/g' /etc/postfix/main.cf
-
-# Install PPA
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
-    apt-get install -y --no-install-recommends nodejs &&\
+#
+# The following line retrieves the latest source code from GitHub.
+# 
+# To obtain the latest stable release run this Docker file with the parameters
+# --no-cache --build-arg DOWNLOAD_TYPE=stable
+#
+# Alternatively for local development, just copy this Dockerfile into file the
+# root of the repository and copy over your local source using : 
+#
+# COPY . /opt/fiware-idm
+#
+RUN if [ ${DOWNLOAD_TYPE} = "latest" ] ; then RELEASE="master"; else RELEASE=$(curl -s https://api.github.com/repos/${GITHUB_ACCOUNT}/${GITHUB_REPOSITORY}/releases/latest | grep 'tag_name' | cut -d\" -f4); fi && \
+    if [ ${DOWNLOAD_TYPE} = "latest" ] ; then echo "INFO: Building Latest Development"; else echo "INFO: Building Release: ${RELEASE}"; fi && \
+    apt-get update && \
+    apt-get install -y  --no-install-recommends unzip && \
+    wget --no-check-certificate -O source.zip https://github.com/${GITHUB_ACCOUNT}/${GITHUB_REPOSITORY}/archive/${RELEASE}.zip && \
+    unzip source.zip && \
+    mv ${GITHUB_REPOSITORY}-${RELEASE} /opt/fiware-idm && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    apt-get remove -y unzip && \
+    apt-get -y autoremove
 
-# Download latest version of the code and install npm dependencies
-RUN git clone https://github.com/ging/fiware-idm.git && \
-    rm -rf doc extras && \
-    cd fiware-idm && \
-    npm cache clean -f && \
-    npm install --production --silent && \
-    rm -rf /root/.npm/cache/*
-
-# Change Workdir
 WORKDIR /opt/fiware-idm
 
-# Create certificates for https
-RUN mkdir certs && \
+RUN rm -rf doc extras  && \
+    npm cache clean -f   && \
+    npm install --production  && \
+    rm -rf /root/.npm/cache/* && \
+    mkdir certs && \
     openssl genrsa -out idm-2018-key.pem 2048 && \
     openssl req -new -sha256 -key idm-2018-key.pem -out idm-2018-csr.pem -batch && \
     openssl x509 -req -in idm-2018-csr.pem -signkey idm-2018-key.pem -out idm-2018-cert.pem && \
     mv idm-2018-key.pem idm-2018-cert.pem idm-2018-csr.pem certs/
+
+
+# For local development, when running the Dockerfile from the root of the repository
+# use the following commands to configure Keyrock, the database and add an entrypoint:
+# 
+# COPY extras/docker/config_database.js  extras/docker/config_database.js
+# COPY extras/docker/config.js.template  extras/docker/config.js
+# COPY extras/docker/docker-entrypoint.sh /opt/fiware-idm/docker-entrypoint.sh
+
 
 # Copy config database file
 COPY config_database.js extras/docker/config_database.js


### PR DESCRIPTION
This PR does the following:

* Use `8.12.0-slim` as base image
* Download release using curl rather than Git
* Add `ARG` to download **latest stable** release  as well as latest githash
* Add comments on how to use the `Dockerfile` locally for development.
* Add `.dockerignore` to ensure **node_modules** are not copied during local development.

## Justification

Using `8.12-slim` aligns Keyrock with the IoT Agents.
The justification for the other changes can be found [here](https://github.com/telefonicaid/iotagent-json/issues/342) - basically trying to make the `Dockerfile` able to do three incompatible jobs:

* Automated builds on DockerHub (as it does now)
* Easily get hold the latest **stable** release (rather than bleeding edge development)
* Enable developers to create a Docker Image based on files from their own code base