### PR TITLE
Fix for #62

### DIFF
--- a/views/templates/email/activate.ejs
+++ b/views/templates/email/activate.ejs
@@ -2,4 +2,4 @@
 
 <p>Welcome to Keyrock! By clicking on the link "I accept" below, you state that you have read and accepted the our Terms and Conditions and the creation of your account will be confirmed:</p>
 
-<p><a href="<%= link %>" target="_blank">I accept</a></p>
+<p><a href= <%= link %> target="_blank">I accept</a></p>

--- a/views/templates/email/change_email.ejs
+++ b/views/templates/email/change_email.ejs
@@ -2,4 +2,4 @@
 
 <p>You have requested to change your email account to this one. Follow the link to finish the process.</p>
 
-<p><a href="<%= link %>" target="_blank">Verify account</a></p>
+<p><a href= <%= link %> target="_blank">Verify account</a></p>

--- a/views/templates/email/forgot_password.ejs
+++ b/views/templates/email/forgot_password.ejs
@@ -2,7 +2,7 @@
 
 <p>Someone has requested a link to change your password. You can do this through the link below.</p>
 
-<p><a href="<%= link %>" target="_blank">Change my password</a></p>
+<p><a href= <%= link %> target="_blank">Change my password</a></p>
 
 <p>If you didn't request this, please ignore this email.</p>
 

--- a/views/templates/email/user_info.ejs
+++ b/views/templates/email/user_info.ejs
@@ -3,4 +3,4 @@
 <p>Password: <%= password %> </p>
 <p>Username: <%= username %> </p>
 <p>You can sign in here: </p>
-<p><a href="<%= link %>" target="_blank"><%= link %></a></p>
+<p><a href= <%= link %> target="_blank"><%= link %></a></p>


### PR DESCRIPTION
Mentioned files use to send the mail without the link("I accept", "Forgot password" etc). 
Links were given as a text and hence, user was unable to confirm the account or change his password. 
After doing changes in mentioned files, now links are being send in confirmation mails.