### PR TITLE
Fix user validation error

### DIFF
--- a/controllers/web/users.js
+++ b/controllers/web/users.js
@@ -697,7 +697,7 @@ exports.create = function(req, res) {
                 '/activate?activation_key=' +
                 activation_key +
                 '&email=' +
-                user.email;
+                encodeURIComponent(user.email); // eslint-disable-line snakecase/snakecase
 
               const mail_data = {
                 name: user.username,
@@ -746,9 +746,9 @@ exports.activate = function(req, res, next) {
       include: [models.user],
     })
     .then(function(user_registration_profile) {
-      const user = user_registration_profile.User;
+      if (user_registration_profile && user_registration_profile.User) {
+        const user = user_registration_profile.User;
 
-      if (user) {
         // Activate the user if is not or if the actual date not exceeds the expiration date
         if (user.enabled) {
           res.locals.message = {
@@ -822,7 +822,7 @@ exports.password_send_email = function(req, res) {
       .then(function(user) {
         if (!user) {
           res.locals.message = {
-            text: `Sorry. You have specified an email address that is not registered. 
+            text: `Sorry. You have specified an email address that is not registered.
                                                If your problem persists, please contact: fiware-lab-help@lists.fiware.org`,
             type: 'danger',
           };
@@ -832,7 +832,7 @@ exports.password_send_email = function(req, res) {
           });
         } else if (!user.enabled) {
           res.locals.message = {
-            text: `The email address you have specified is registered but not activated. 
+            text: `The email address you have specified is registered but not activated.
                                                Please check your email for the activation link or request a new one.
                                                If your problem persists, please contact: fiware-lab-help@lists.fiware.org`,
             type: 'danger',
@@ -1091,7 +1091,7 @@ exports.resend_confirmation = function(req, res) {
           }
         } else {
           res.locals.message = {
-            text: `Sorry. You have specified an email address that is not registerd. 
+            text: `Sorry. You have specified an email address that is not registerd.
                                                If your problem persists, please contact: fiware-lab-help@lists.fiware.org`,
             type: 'danger',
           };


### PR DESCRIPTION
When users register with email containing special characters such as `+` and click on the validation link, they get the following error:

```
TypeError: Cannot read property 'User' of null
    at /opt/fiware-idm/controllers/web/users.js:749:46
    at tryCatcher (/opt/fiware-idm/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/opt/fiware-idm/node_modules/bluebird/js/release/promise.js:512:31)
    at Promise._settlePromise (/opt/fiware-idm/node_modules/bluebird/js/release/promise.js:569:18)
    at Promise._settlePromise0 (/opt/fiware-idm/node_modules/bluebird/js/release/promise.js:614:10)
    at Promise._settlePromises (/opt/fiware-idm/node_modules/bluebird/js/release/promise.js:693:18)
    at Async._drainQueue (/opt/fiware-idm/node_modules/bluebird/js/release/async.js:133:16)
    at Async._drainQueues (/opt/fiware-idm/node_modules/bluebird/js/release/async.js:143:10)
    at Immediate.Async.drainQueues (/opt/fiware-idm/node_modules/bluebird/js/release/async.js:17:14)
    at runCallback (timers.js:810:20)
    at tryOnImmediate (timers.js:768:5)
    at processImmediate [as _immediateCallback] (timers.js:745:5)
```

This happens because the special characters are not encoded in the url of the link in the email, hence the query to retrieve the user cannot match it.

This PR contains 2 changes to address the issue:
- URI Encore the email in the email
- Change the check in the backend to first check if the query returned a row, and if not display the generic error message rather than the stack-trace. 