### PR TITLE
Add PUT endpoint for idempotent action

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1371,7 +1371,7 @@ Applications are registered in Keyrock and consume OAuth2 resources.
     + role_id - Id of the role.
     + permission_id - Id of the permission.
 
-### Assign a permission to a role [POST]
+### Assign a permission to a role [PUT]
 + Request (application/json)
     + Headers
         
@@ -1497,7 +1497,7 @@ Applications are registered in Keyrock and consume OAuth2 resources.
     + application_id - Id of the application.
     + role_id - Id of the role.
 
-### Assign a role to a user [POST]
+### Assign a role to a user [PUT]
 + Request (application/json)
     + Headers
         
@@ -1644,7 +1644,7 @@ Applications are registered in Keyrock and consume OAuth2 resources.
     + role_id - Id of the role.
     + organization_role_id - Id of organization role.
 
-### Assign a role to a organization [POST]
+### Assign a role to a organization [PUT]
 + Request (application/json)
     + Headers
         
@@ -1767,7 +1767,7 @@ Applications are registered in Keyrock and consume OAuth2 resources.
     + user_id - Id of the user.
     + organization_role_id - Id of the organization role.
 
-### Create relationship [POST]        
+### Create relationship [PUT]        
 + Request (application/json)
     + Headers
         

--- a/routes/api/applications.js
+++ b/routes/api/applications.js
@@ -102,13 +102,18 @@ router.get(
   '/:application_id/roles/:role_id/permissions',
   api_role_pem_assign_controller.index
 );
-router.post(
+router.put(
   '/:application_id/roles/:role_id/permissions/:permission_id',
   api_role_pem_assign_controller.create
 );
 router.delete(
   '/:application_id/roles/:role_id/permissions/:permission_id',
   api_role_pem_assign_controller.delete
+);
+// POST endpoint is deprecated - maintained for backwards compatibility
+router.post(
+  '/:application_id/roles/:role_id/permissions/:permission_id',
+  api_role_pem_assign_controller.create
 );
 
 // Routes for role_user_assignments


### PR DESCRIPTION
Assign a permission to a role is an idempotent action. As a well-defined HTTP  API should do this using  the PUT verb:
 
```console
curl -iX PUT \
  'http://localhost:3005/v1/applications/{{application-id}}/roles/{{role-id}}/permissions/{{permission-id}}' \
  -H 'Content-Type: application/json' \
  -H 'X-Auth-token: {{X-Auth-token}}'
```

Related:  https://github.com/FIWARE/tutorials.Roles-Permissions/issues/7

It looks like this endpoint was missed or lost since ging/fiware-idm#34

This PR adds a PUT endpoint for this idempotent action whilst maintaining backwards compatibility. POST.

