### PR TITLE
Replace value of attributes to empty object in oauth_user_response.json

### DIFF
--- a/templates/oauth_response/oauth_user_response.json
+++ b/templates/oauth_response/oauth_user_response.json
@@ -11,5 +11,5 @@
     "authorization_decision": "",
     "app_azf_domain": "",
     "eidas_profile": {},
-    "attributes": ""
+    "attributes": {}
 }


### PR DESCRIPTION
Hi @apozohue10,

I think that when the attributes variable in oauth_user_response don't have values, it should be empty object {}. Because when it has values, it become an object as follows.

```
{
  "organizations": [],
  "displayName": "",
  "roles": [],
  "app_id": "7c521237-9769-4625-8335-35acd72c8efe",
  "trusted_apps": [],
  "isGravatarEnabled": false,
  "image": "",
  "email": "admin@fisuda",
  "id": "admin",
  "authorization_decision": "",
  "app_azf_domain": "",
  "eidas_profile": {},
  "attributes": {
    "color": "3",
    "reach": "1",
    "vocal": "0",
    "vision": "3",
    "hearing": "1",
    "cognition": "2",
    "manipulation": "1"
  },
  "username": "admin"
}
```

Thank you.