### PR TITLE
Add Helmet to provide various security headers

### DIFF
--- a/app.js
+++ b/app.js
@@ -41,7 +41,12 @@ app.disable('x-powered-by');
 // Set security headers
 app.use(
   helmet.contentSecurityPolicy({
-    reportOnly: process.env.IDM_REPORT_ONLY === 'true', // eslint-disable-line snakecase/snakecase
+    directives: {
+      defaultSrc: ["'self'"], // eslint-disable-line snakecase/snakecase
+      scriptSrc: ["'self'", "'unsafe-inline'"], // eslint-disable-line snakecase/snakecase
+      styleSrc: ["'self'", 'https:', "'unsafe-inline'"], // eslint-disable-line snakecase/snakecase
+    },
+    reportOnly: false, // eslint-disable-line snakecase/snakecase
   })
 );
 app.use(

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "express-session": "^1.15.6",
     "express-useragent": "^1.0.13",
     "gravatar": "^1.6.0",
+    "helmet": "^4.1.0",
     "http": "0.0.0",
     "https": "^1.0.0",
     "i18n-express": "^1.1.3",


### PR DESCRIPTION
*Helmet.js* is a Node.js module that helps in securing HTTP headers. It is implemented in express applications. Therefore, we can say that *helmet.js* helps in securing express applications. It sets up various HTTP headers to prevent attacks like Cross-Site-Scripting(XSS), clickjacking, etc.

- https://helmetjs.github.io/
- https://www.geeksforgeeks.org/node-js-securing-apps-with-helmet-js/
- https://github.com/helmetjs/helmet