### PR TITLE
Fix scope validation for grant_type password

### DIFF
--- a/models/model_oauth_server.js
+++ b/models/model_oauth_server.js
@@ -830,7 +830,7 @@ function validateScope(user, client, scope) {
   debug('-------validateScope-------');
 
   if (scope && scope.length > 0) {
-    const requested_scopes = scope[0].split(',');
+    const requested_scopes = typeof scope === "string" ? scope.split(',') : scope[0].split(',');
     if (requested_scopes.includes('bearer') && requested_scopes.includes('jwt')) {
       return false;
     }


### PR DESCRIPTION
## Proposed changes

Currently, the OAuth2 `scope` parameter cannot be used when issuing tokens using the `grant_type` `password`. For example, making the following request:

```
$ export CLIENT_CREDENTIALS=`echo -n "${CLIENT_ID}:${CLIENT_SECRET}" | base64`
$ curl -v http://localhost:3000/oauth2/token -d "grant_type=password&scope=jwt&username=admin@test.com&password=1234" -H "application/x-www-form-urlencoded" -H "Authorization: Basic ${CLIENT_CREDENTIALS}"
```

result in a normal token and the associated scope is `j` insteadof `jwt`:

```
{
    "access_token": "9ee6e9c2c15dc96ff7f673f7c3ea2f987125dee0",
    "token_type": "bearer",
    "expires_in": 3599,
    "refresh_token": "35a5773adce7923c162963f37345957288bdd257",
    "scope": [
        "j"
    ]
}
```

## Types of changes

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/ging/fiware-idm/blob/master/CONTRIBUTING.md) doc
-   [x] I have signed the [CLA](https://github.com/ging/fiware-idm/blob/master/keyrock-individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

As far as I know, there are not unit tests for the affected code. It would be great if you can provide some example/template/guidelines of how to create such tests.