### PR TITLE
Add a migration for initializing the visible_attributes data when migrating from a previous version of KeyRock

### DIFF
--- a/migrations/20210422214057-init-visible_attributes.js
+++ b/migrations/20210422214057-init-visible_attributes.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+      return queryInterface.bulkUpdate('user', { extra: '{"visible_attributes": ["username", "description", "website", "identity_attributes", "image", "gravatar"]}' }, { extra: null });
+  },
+
+  down: (queryInterface, Sequelize) => {
+      return Promise.resolve();
+  }
+};


### PR DESCRIPTION
## Proposed changes

This PR adds a migration for adding the `visible_attribute` extra data when migrating form old versions of KeyRock.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in
the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality
        to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

-   [x] I have read the
        [CONTRIBUTING](https://github.com/ging/fiware-idm/blob/master/CONTRIBUTING.md)
        doc
-   [x] I have signed the
        [CLA](https://github.com/ging/fiware-idm/blob/master/keyrock-individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature
        works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream
        modules

## Further comments

I really don't know in what version the `visible_attributes` data was added, in any case, the migration only inits this parameter if the `extra` column is `null`.