### PR TITLE
Use access_token hashes as primary key

### DIFF
--- a/controllers/api/authenticate_oauth.js
+++ b/controllers/api/authenticate_oauth.js
@@ -4,6 +4,8 @@ const config_service = require('../../lib/configService.js');
 const config_authzforce = config_service.get_config().authzforce;
 const debug = require('debug')('idm:api-authenticate_oauth');
 
+const crypto = require('crypto');
+
 const Sequelize = require('sequelize');
 const Op = Sequelize.Op;
 
@@ -137,7 +139,9 @@ exports.info_token = function (req, res) {
 function search_auth_token(token_id) {
   return models.auth_token
     .findOne({
-      where: { access_token: token_id },
+      where: {
+        hash: crypto.createHash("sha3-256").update(token_id).digest('hex')
+      },
       include: [
         {
           model: models.pep_proxy,

--- a/migrations/20210603073911-hashed-access-tokens.js
+++ b/migrations/20210603073911-hashed-access-tokens.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const crypto = require('crypto');
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('oauth_access_token', 'hash', {
+      type: Sequelize.CHAR(64),
+      primaryKey: false,
+      allowNull: true,   // We need this to be able to fill data before disallowing null values
+      defaultValue: null,
+      unique: false      // Initially, all access tokens will have a null hash value
+    }).then(() => {
+      return queryInterface.sequelize.query("SELECT access_token FROM oauth_access_token", { type: Sequelize.QueryTypes.SELECT });
+    }).then((rows) => {
+      // Provide an initial value for the hash column
+      return Promise.all(rows.map((row) => {
+        return queryInterface.bulkUpdate(
+          "oauth_access_token",
+          {hash: crypto.createHash("sha3-256").update(row.access_token).digest('hex')},
+          {access_token: row.access_token}
+        );
+      }));
+    }).then(() => {
+      // Remove access_token as primary key
+      return queryInterface.removeConstraint('oauth_access_token', 'access_token');
+    }).then(() => {
+      return queryInterface.removeConstraint('oauth_access_token', 'PRIMARY');
+    }).then(() => {
+      // Now that the access_token column is not a primary key
+      // use an unlimited text column so JWT can be store without any problem
+      return queryInterface.changeColumn('oauth_access_token', 'access_token', {
+        type: Sequelize.TEXT,
+        allowNull: false,
+        unique: false
+      });
+    }).then(() => {
+      // Make hash column unique
+      return queryInterface.addConstraint('oauth_access_token', {
+        fields: [ 'hash' ],
+        type: 'unique'
+      });
+    }).then(() => {
+      // Make hash column the primary key
+      return queryInterface.addConstraint('oauth_access_token', {
+        fields: [ 'hash' ],
+        type: 'primary key'
+      });
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.changeColumn('oauth_access_token', 'access_token', {
+      type: Sequelize.STRING,
+      allowNull: false
+    }).then(() => {
+      return queryInterface.removeConstraint('oauth_access_token', 'PRIMARY');
+    }).then(() => {
+      return queryInterface.addConstraint('oauth_access_token', {
+        fields: [ 'access_token' ],
+        type: 'unique'
+      });
+    }).then(() => {
+      return queryInterface.addConstraint('oauth_access_token', {
+        fields: [ 'access_token' ],
+        type: 'primary key'
+      });
+    }).then(() => {
+      return queryInterface.removeColumn('oauth_access_token', 'hash');
+    });
+  }
+};

--- a/models/oauth2/oauth_access_token.js
+++ b/models/oauth2/oauth_access_token.js
@@ -4,9 +4,14 @@ module.exports = function (sequelize, DataTypes) {
   const OAuthAccessToken = sequelize.define(
     'OauthAccessToken',
     {
-      access_token: {
-        type: DataTypes.STRING,
+      hash: {
+        type: DataTypes.CHAR(64),
         primaryKey: true,
+        allowNull: false,
+        unique: true
+      },
+      access_token: {
+        type: DataTypes.TEXT,
         allowNull: false,
         unique: true
       },


### PR DESCRIPTION
## Proposed changes

This PR adds a new `hash` column into the `oauth_access_token` table and switches the table to use it as primary key. This will allow keyrock to store bigger access tokens, like JWT with more or bigger claims.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in
the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality
        to not work as expected)

## Checklist

-   [x] I have read the
        [CONTRIBUTING](https://github.com/ging/fiware-idm/blob/master/CONTRIBUTING.md)
        doc
-   [x] I have signed the
        [CLA](https://github.com/ging/fiware-idm/blob/master/keyrock-individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature
        works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream
        modules

## Further comments

N/A
