### PR TITLE
Add missing redirect_sign_out_uri to apiary api doc

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -204,6 +204,7 @@ Applications are registered in Keyrock and consume OAuth2 resources.
               "image": "default",
               "url": "http://localhost",
               "redirect_uri": "http://localhost/login",
+              "redirect_sign_out_uri": "http://localhost/logout",
               "grant_type": "client_credentials,password,implicit,authorization_code,refresh_token",
               "response_type": "code,token",
               "token_types": "bearer,jwt,permanent",
@@ -216,6 +217,7 @@ Applications are registered in Keyrock and consume OAuth2 resources.
               "image": "default",
               "url": "http://localhost",
               "redirect_uri": "http://localhost/login",
+              "redirect_sign_out_uri": "http://localhost/logout",
               "grant_type": "password,authorization_code,implicit",
               "response_type": "code,token",
               "token_types": "bearer",
@@ -238,6 +240,7 @@ Applications are registered in Keyrock and consume OAuth2 resources.
             "name": "Test_application 1",
             "description": "description",
             "redirect_uri": "http://localhost/login",
+            "redirect_sign_out_uri": "http://localhost/logout",
             "url": "http://localhost",
             "grant_type": [
               "authorization_code",
@@ -273,6 +276,7 @@ Applications are registered in Keyrock and consume OAuth2 resources.
             "name": "Test_application 1",
             "description": "description",
             "redirect_uri": "http://localhost/login",
+            "redirect_sign_out_uri": "http://localhost/logout",
             "url": "http://localhost",
             "grant_type": "password,authorization_code,implicit",
             "token_types": "jwt,permanent",
@@ -313,6 +317,7 @@ Applications are registered in Keyrock and consume OAuth2 resources.
                     "secret": "61f5def7-bcf9-45b1-9c69-d0887e403737",
                     "url": "http://localhost",
                     "redirect_uri": "http://localhost/login",
+                    "redirect_sign_out_uri": "http://localhost/logout"
                     "image": "default",
                     "grant_type": "client_credentials,password,implicit,authorization_code,refresh_token",
                     "response_type": "code,token",
@@ -338,6 +343,7 @@ Applications are registered in Keyrock and consume OAuth2 resources.
                 "name": "new name",
                 "description": "new description",
                 "redirect_uri": "new redirect uri",
+                "redirect_sign_out_uri": "new redirect sign out uri",
                 "token_types": ["permanent"]
                 "grant_type": [
                     "authorization_code",
@@ -366,6 +372,7 @@ Applications are registered in Keyrock and consume OAuth2 resources.
             "name": "new name",
             "description": "new description",
             "redirect_uri": "new redirect uri",
+            "redirect_sign_out_uri": "new redirect sign out uri",
             "grant_type": "password,authorization_code",
             "token_types": "bearer,permanent",
             "jwt_secret": null,


### PR DESCRIPTION
I was playing around with the API and found that the parameter redirect_sign_out_uri was missing in the apiary doc

## Proposed changes

Update documentation

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in
the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality
        to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

-   [x] I have read the
        [CONTRIBUTING](https://github.com/ging/fiware-idm/blob/master/CONTRIBUTING.md)
        doc
-   [x] I have signed the
        [CLA](https://github.com/ging/fiware-idm/blob/master/keyrock-individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature
        works
-   [x] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream
        modules


