### PR TITLE
Add support for using external participant and authorization registries (part 2)

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,6 +24,7 @@ const index = require('./routes/web/index');
 const api = require('./routes/api/index');
 const oauth2 = require('./routes/oauth2/oauth2');
 const saml2 = require('./routes/saml2/saml2');
+const authregistry = require('./routes/authregistry/authregistry');
 
 const app = express();
 const helmet = require('helmet');
@@ -183,6 +184,11 @@ if (config.https.enabled) {
   // Set routes for saml2
   app.use('/saml2', force_ssl, saml2);
 
+  // Set routes for the authorization registry if enabled
+  if (config.ar.url === "internal") {
+    app.use('/ar', authregistry);
+  }
+
   // Set routes for GUI
   app.use('/', force_ssl, index);
 } else {
@@ -196,6 +202,11 @@ if (config.https.enabled) {
 
   // Set routes for saml2
   app.use('/saml2', saml2);
+
+  // Set routes for the authorization registry if enabled
+  if (config.ar.url === "internal") {
+    app.use('/ar', authregistry);
+  }
 
   // Set routes for GUI
   app.use('/', index);

--- a/controllers/authregistry/authregistry.js
+++ b/controllers/authregistry/authregistry.js
@@ -51,6 +51,15 @@ const get_delegation_evidence = async function get_delegation_evidence(subject) 
 const _upsert_policy = async function _upsert_policy(req, res) {
   const token_info = await authenticate_bearer(req);
 
+  const authorized_email = `${config.pr.client_id}@${config.pr.url}`;
+  if (!token_info.user.admin && token_info.user.email !== authorized_email) {
+    res.status(403).json({
+      error: "You are not authorized to update policies",
+      details: validate_delegation_evicence.errors
+    });
+    return true;
+  }
+
   debug(`User ${token_info.user.username}`);
   if (!validate_delegation_evicence(req.body)) {
     debug(validate_delegation_evicence.errors);

--- a/controllers/authregistry/authregistry.js
+++ b/controllers/authregistry/authregistry.js
@@ -1,0 +1,258 @@
+const debug = require('debug')('idm:authregistry_controller');
+const Ajv = require('ajv');
+const ajv = new Ajv();
+const fs = require('fs');
+const path = require('path');
+const oauth2_server = require('oauth2-server'); //eslint-disable-line snakecase/snakecase
+
+const config_service = require('../../lib/configService.js');
+const models = require('../../models/models.js');
+const Request = oauth2_server.Request;
+const Response = oauth2_server.Response;
+
+const config = config_service.get_config();
+const delegation_evidence_schema = JSON.parse(fs.readFileSync(path.join(__dirname, 'delegationEvidenceSchema.json')));
+const validate_delegation_evicence = ajv.compile(delegation_evidence_schema);
+const delegation_request_schema = JSON.parse(fs.readFileSync(path.join(__dirname, 'delegationRequestSchema.json')));
+const validate_delegation_request = ajv.compile(delegation_request_schema);
+
+// Create Oauth Server model
+const oauth2 = new oauth2_server({ //eslint-disable-line new-cap
+  model: require('../../models/model_oauth_server.js'),
+  debug: true
+});
+
+
+const authenticate_bearer = async function authenticate_bearer(req) {
+  const options = {};
+
+  const request = new Request({
+    headers: { authorization: req.headers.authorization },
+    method: "POST",
+    query: {}
+  });
+
+  const response = new Response();
+
+  return await oauth2.authenticate(request, response, options);
+}
+
+const get_delegation_evidence = async function get_delegation_evidence(user) {
+  return await models.delegation_evidence.findOne({
+    where: {
+      policy_issuer: config.pr.client_id,
+      access_subject: user.id
+    }
+  });
+};
+
+const _upsert_policy = async function _upsert_policy(req, res) {
+  const token_info = await authenticate_bearer(req);
+
+  debug(`User ${token_info.user.username}`);
+  if (!validate_delegation_evicence(req.body)) {
+    debug(validate_delegation_evicence.errors);
+    return res.status(400).json({
+      error: "Invalid policy document",
+      details: validate_delegation_evicence.errors
+    });
+  }
+
+  const evidence = req.body.delegationEvidence;
+
+  // Check policyIssuer
+  if (evidence.policyIssuer !== config.pr.client_id) {
+    return res.status(422).json({
+      error: `Invalid value for policyIssuer: ${evidence.policyIssuer}`
+    });
+  }
+
+  // Check target.accessSubject
+  // At this moment, we are only allowing policies targeting internal users
+  const target = await models.user.findOne({
+    where: {
+      id: evidence.target.accessSubject
+    }
+  });
+
+  if (target == null) {
+    return res.status(422).json({
+      error: `Invalid value for target.accessSubject: ${evidence.target.accessSubject}`
+    });
+  }
+
+  // Create/update sent policy
+  models.delegation_evidence.upsert({
+    policy_issuer: evidence.policyIssuer,
+    access_subject: evidence.target.accessSubject,
+    policy: evidence
+  });
+
+  return res.status(200).json({});
+};
+
+const is_matching_policy = function is_matching_policy(policy_mask, policy) {
+  // Check resource type
+  if (policy.target.resource.type !== policy_mask.target.resource.type) {
+    return false;
+  }
+
+  // Check provider
+  if (policy.target.environment != null) {
+    if (policy_mask.target.environment == null) {
+      return false;
+    }
+
+    const service_providers_mask = policy_mask.target.environment.serviceProviders;
+    const service_providers = policy.target.environment.serviceProviders;
+    const all_mask_sp = service_providers_mask.every(sp => service_providers.has(sp));
+    if (!all_mask_sp) {
+      return false;
+    }
+  }
+
+  const resource = policy.target.resource;
+
+  // Check identifiers
+  const id_match = policy_mask.target.resource.identifiers.every(
+    mid => {return resource.identifiers.length === 1 && resource.identifiers.includes("*") || resource.identifiers.includes(mid);}
+  );
+  if (!id_match) {
+    return false;
+  }
+
+  // Check attributes
+  const attributes_match = policy_mask.target.resource.attributes.every(
+    aid => {return resource.attributes.length === 1 && resource.attributes.includes("*") || resource.attributes.includes(aid);}
+  );
+  if (!attributes_match) {
+    return false;
+  }
+
+  // Check actions
+  return policy_mask.target.actions != null &&
+         policy_mask.target.actions.length > 0 &&
+         policy_mask.target.actions.every(
+           mact => {return policy.target.actions.length === 1 && policy.target.actions.includes("*") || policy.target.actions.includes(mact);}
+         );
+};
+
+const is_denying_permission = function is_denying_permission(policy_mask, policy) {
+  return policy.rules.reverse().some(rule => rule.effect === "Deny" &&
+      rule.target.resource.type === policy_mask.target.resource.type &&
+      (rule.target.resource.identifiers.includes("*") || policy_mask.target.resource.identifiers.some(i => rule.target.resource.identifiers.includes(i))) &&
+      (rule.target.resource.attributes.includes("*") || policy_mask.target.resource.attributes.some(a => rule.target.resource.attributes.includes(a))) &&
+      (rule.target.actions.length === 0 || rule.target.actions.includes("*") || policy_mask.target.actions.some(a => rule.target.actions.includes(a)))
+  );
+};
+
+const _query_evidences = async function _query_evidences(req, res) {
+  const token_info = await authenticate_bearer(req);
+
+  debug(`Requesting delegation evidences affecing user ${token_info.user.username} (id: ${token_info.user.id})`);
+
+  debug('Validating delegation mask structure');
+
+  if (!validate_delegation_request(req.body)) {
+    debug(validate_delegation_request.errors);
+    res.status(400).json({
+      error: "Invalid mask document",
+      details: validate_delegation_request.errors
+    });
+    return true;
+  }
+  const mask = req.body.delegationRequest;
+
+  debug('Requesting available delegation evidences');
+
+  const evidence = await get_delegation_evidence(token_info.user);
+  if (evidence == null) {
+    res.status(404);
+    return true;
+  }
+
+  debug('Filtering delegation evidence using the provided mask');
+
+  evidence.policySets = mask.policySets.flatMap((policy_set_mask, i) => {
+
+    debug(`Processing policy set ${i} from the providen mask`);
+
+    return evidence.policySets.map((policy_set, j) => {
+      debug(`  Processing policy set ${j} from the available delegation evidence`);
+
+      const response_policy_set = {
+        maxDelegationDepth: policy_set.maxDelegationDepth, //eslint-disable-line snakecase/snakecase
+        target: policy_set.target
+      };
+
+      response_policy_set.policies = policy_set_mask.policies.forEach((policy_mask) => {
+        const matching_policies = policy_set.policies.filter((policy) => is_matching_policy(policy_mask, policy));
+        return {
+          target: policy_mask.target,
+          rules: [{
+            effect: (matching_policies.length === 0 || matching_policies.some(p => is_denying_permission(policy_mask, p))) ? "Deny": "Permit"
+          }]
+        };
+      });
+
+      return response_policy_set;
+    });
+  });
+
+  res.status(200).json({delegation_token: /*extparticipant.create_jwt(*/evidence/*)*/});
+  return false;
+};
+
+exports.oauth2 = oauth2;
+exports.get_delegation_evidence = get_delegation_evidence;
+exports.upsert_policy = function upsert_policy(req, res, next) {
+  debug(' --> policy');
+  _upsert_policy(req, res).then(
+    next,
+    (err) => {
+      if (err instanceof oauth2_server.OAuthError) {
+        debug('Error ', err.message);
+        if (err.details) {
+          debug('Due: ', err.details);
+        }
+        res.status(err.status = err.code);
+
+        res.locals.error = err;
+        res.render('errors/oauth', {
+          query: {},
+          application: req.application
+        });
+      } else {
+        res.status(500);
+      }
+    }
+  );
+};
+
+exports.query_evidences = function query_evidences(req, res, next) {
+  debug(' --> delegate');
+  _query_evidences(req, res).then(
+    (skip) => {
+      if (!skip) {
+        next();
+      }
+    },
+    (err) => {
+      if (err instanceof oauth2_server.OAuthError) {
+        debug('Error ', err.message);
+        if (err.details) {
+          debug('Due: ', err.details);
+        }
+        res.status(err.status);
+
+        res.locals.error = err;
+        res.render('errors/oauth', {
+          query: {},
+          application: req.application
+        });
+      } else {
+        res.status(500);
+      }
+    }
+  );
+};

--- a/controllers/authregistry/authregistry.js
+++ b/controllers/authregistry/authregistry.js
@@ -52,7 +52,7 @@ const _upsert_policy = async function _upsert_policy(req, res) {
   const token_info = await authenticate_bearer(req);
 
   const authorized_email = `${config.pr.client_id}@${config.pr.url}`;
-  if (!token_info.user.admin && token_info.user.email !== authorized_email) {
+  if (!token_info.user.admin && token_info.user.email !== authorized_email) {
     res.status(403).json({
       error: "You are not authorized to update policies",
       details: validate_delegation_evicence.errors
@@ -172,7 +172,7 @@ const _query_evidences = async function _query_evidences(req, res) {
 
   debug('Filtering delegation evidence using the provided mask');
 
-  const newPolicySets = mask.policySets.flatMap((policy_set_mask, i) => {
+  const new_policy_sets = mask.policySets.flatMap((policy_set_mask, i) => {
 
     debug(`Processing policy set ${i} from the providen mask`);
 
@@ -198,7 +198,7 @@ const _query_evidences = async function _query_evidences(req, res) {
       return response_policy_set;
     });
   });
-  evidence.policySets = newPolicySets;
+  evidence.policySets = new_policy_sets;
 
   debug("Delegation evidence processed");
   res.status(200).json({delegation_token: await utils.create_jwt(evidence)});

--- a/controllers/authregistry/authregistry.js
+++ b/controllers/authregistry/authregistry.js
@@ -230,7 +230,11 @@ exports.upsert_policy = function upsert_policy(req, res, next) {
           application: req.application
         });
       } else {
-        throw err;
+        res.status(500).json({
+          message: err,
+          code: 500,
+          title: 'Internal Server Error'
+        });
       }
     }
   );
@@ -258,7 +262,11 @@ exports.query_evidences = function query_evidences(req, res, next) {
           application: req.application
         });
       } else {
-        throw err;
+        res.status(500).json({
+          message: err,
+          code: 500,
+          title: 'Internal Server Error'
+        });
       }
     }
   );

--- a/controllers/authregistry/delegationEvidenceSchema.json
+++ b/controllers/authregistry/delegationEvidenceSchema.json
@@ -1,0 +1,214 @@
+{
+  "definitions": {
+    "accessSubject": {
+      "type": "string",
+      "pattern": "^\\S+$"
+    },
+    "type": {
+      "type": "string",
+      "pattern": "^[^\\s\\*]+$"
+    },
+    "identifiers": {
+      "type": "array",
+      "uniqueItems": true,
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "pattern": "^\\S+$"
+      }
+    },
+    "attributes": {
+      "type": "array",
+      "uniqueItems": true,
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "pattern": "^\\S+$"
+      }
+    },
+    "actions": {
+      "type": "array",
+      "uniqueItems": true,
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "pattern": "^\\S+$"
+      }
+    },
+    "effect": {
+      "type": "string",
+      "enum": [
+        "Permit",
+        "Deny"
+      ]
+    },
+    "rules": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [ "effect" ],
+        "properties": {
+          "effect": {
+            "$ref": "#/definitions/effect"
+          }
+        },
+        "additionalProperties": {
+          "target": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [ "resource" ],
+            "properties": {
+              "resource": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "type": {
+                    "$ref": "#/definitions/type"
+                  },
+                  "identifiers": {
+                    "$ref": "#/definitions/identifiers"
+                  },
+                  "attributes": {
+                    "$ref": "#/definitions/attributes"
+                  }
+                }
+              },
+              "actions": {
+                "$ref": "#/definitions/actions"
+              }
+            }
+          }
+        }
+      }
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [ "resource", "actions" ],
+      "properties": {
+        "resource": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [ "type", "identifiers" ],
+          "properties": {
+            "type": {
+              "$ref": "#/definitions/type"
+            },
+            "identifiers": {
+              "$ref": "#/definitions/identifiers"
+            },
+            "attributes": {
+              "$ref": "#/definitions/attributes"
+            }
+          }
+        },
+        "actions": {
+          "$ref": "#/definitions/actions"
+        },
+        "environment": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [ "serviceProviders" ],
+          "properties": {
+            "serviceProviders": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "policies": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [ "target", "rules" ],
+        "properties": {
+          "target": {
+            "$ref": "#/definitions/target"
+          },
+          "rules": {
+            "$ref": "#/definitions/rules"
+          }
+        }
+      }
+    }
+  },
+
+  "type": "object",
+  "required": ["delegationEvidence"],
+  "additionalProperties": false,
+  "properties": {
+    "delegationEvidence": {
+      "type": "object",
+      "required": [ "notOnOrAfter", "notBefore", "policyIssuer", "target", "policySets" ],
+      "additionalProperties": false,
+      "properties": {
+        "notBefore": {
+          "type": "integer"
+        },
+        "notOnOrAfter": {
+          "type": "integer"
+        },
+        "policyIssuer": {
+          "type": "string",
+          "pattern": "^\\S+$"
+        },
+        "target": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [ "accessSubject" ],
+          "properties": {
+            "accessSubject": {
+              "$ref": "#/definitions/accessSubject"
+            }
+          }
+        },
+        "policySets": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [ "policies", "target" ],
+            "properties": {
+              "maxDelegationDepth": {
+                "type": "integer"
+              },
+              "target": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [ "environment" ],
+                "properties": {
+                  "environment": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [ "licenses" ],
+                    "properties": {
+                      "licenses": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "policies": {
+                "$ref": "#/definitions/policies"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/controllers/authregistry/delegationRequestSchema.json
+++ b/controllers/authregistry/delegationRequestSchema.json
@@ -1,0 +1,198 @@
+{
+  "definitions": {
+    "accessSubject": {
+      "type": "string",
+      "pattern": "^\\S+$"
+    },
+    "type": {
+      "type": "string",
+      "pattern": "^[^\\s\\*]+$"
+    },
+    "identifiers": {
+      "type": "array",
+      "uniqueItems": true,
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "pattern": "^\\S+$"
+      }
+    },
+    "attributes": {
+      "type": "array",
+      "uniqueItems": true,
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "pattern": "^\\S+$"
+      }
+    },
+    "actions": {
+      "type": "array",
+      "uniqueItems": true,
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "pattern": "^\\S+$"
+      }
+    },
+    "effect": {
+      "type": "string",
+      "enum": [
+        "Permit",
+        "Deny"
+      ]
+    },
+    "rules": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [ "effect" ],
+        "properties": {
+          "effect": {
+            "$ref": "#/definitions/effect"
+          }
+        },
+        "additionalProperties": {
+          "target": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [ "resource" ],
+            "properties": {
+              "resource": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "type": {
+                    "$ref": "#/definitions/type"
+                  },
+                  "identifiers": {
+                    "$ref": "#/definitions/identifiers"
+                  },
+                  "attributes": {
+                    "$ref": "#/definitions/attributes"
+                  }
+                }
+              },
+              "actions": {
+                "$ref": "#/definitions/actions"
+              }
+            }
+          }
+        }
+      }
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [ "resource", "actions" ],
+      "properties": {
+        "resource": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [ "type", "identifiers" ],
+          "properties": {
+            "type": {
+              "$ref": "#/definitions/type"
+            },
+            "identifiers": {
+              "$ref": "#/definitions/identifiers"
+            },
+            "attributes": {
+              "$ref": "#/definitions/attributes"
+            }
+          }
+        },
+        "actions": {
+          "$ref": "#/definitions/actions"
+        },
+        "environment": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [ "serviceProviders" ],
+          "properties": {
+            "serviceProviders": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "policies": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [ "target", "rules" ],
+        "properties": {
+          "target": {
+            "$ref": "#/definitions/target"
+          },
+          "rules": {
+            "$ref": "#/definitions/rules"
+          }
+        }
+      }
+    }
+  },
+
+  "type": "object",
+  "required": ["delegationRequest"],
+  "additionalProperties": false,
+  "properties": {
+    "delegationRequest": {
+      "type": "object",
+      "required": [ "policyIssuer", "target", "policySets" ],
+      "additionalProperties": false,
+      "properties": {
+        "policyIssuer": {
+          "type": "string",
+          "pattern": "^\\S+$"
+        },
+        "target": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [ "accessSubject" ],
+          "properties": {
+            "accessSubject": {
+              "$ref": "#/definitions/accessSubject"
+            }
+          }
+        },
+        "policySets": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [ "policies" ],
+            "properties": {
+              "policies": {
+                "$ref": "#/definitions/policies"
+              }
+            }
+          }
+        },
+        "delegation_path": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^\\S+$"
+          }
+        },
+        "previous_steps": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^\\S+$"
+          }
+        }
+      }
+    }
+  }
+}

--- a/controllers/extparticipant/extparticipant.js
+++ b/controllers/extparticipant/extparticipant.js
@@ -386,7 +386,7 @@ async function _token(req, res) {
     await models.user.upsert({
       username: client_payload.iss,
       description: `External participant with id: ${client_payload.iss}`,
-      email: `${client_id}@${client_payload.iss}`,
+      email: `${client_id}@${config.pr.url}`,
     }, {
       validate: false // Currently, we are inserting an invalid email address for the participant
     });

--- a/controllers/extparticipant/extparticipant.js
+++ b/controllers/extparticipant/extparticipant.js
@@ -1,5 +1,5 @@
 const crypto = require('crypto');
-const debug = require('debug')('idm:i4trust_controller');
+const debug = require('debug')('idm:extparticipant_controller');
 const fetch = require('node-fetch');
 const forge = require('node-forge');
 const jose = require('node-jose');

--- a/controllers/extparticipant/utils.js
+++ b/controllers/extparticipant/utils.js
@@ -1,0 +1,42 @@
+const config_service = require('../../lib/configService.js');
+const debug = require('debug')('idm:extparticipant_utils');
+const jose = require('node-jose');
+
+const config = config_service.get_config();
+
+const crt_regex = /^-----BEGIN CERTIFICATE-----\n([\s\S]+?)\n-----END CERTIFICATE-----$/gm;
+
+const ensure_client_key_is_ready = async function ensure_client_key_is_ready() {
+  if (typeof config.pr.client_key === "string") {
+    debug('preparing Participant Key & client certificate');
+    config.pr.client_key = await jose.JWK.asKey(config.pr.client_key, "pem");
+    if (config.pr.client_crt.indexOf("-----BEGIN CERTIFICATE-----") !== -1) {
+      const str = config.pr.client_crt;
+      config.pr.client_crt = [];
+      let m;
+      while ((m = crt_regex.exec(str)) !== null) {
+        // This is necessary to avoid infinite loops with zero-width matches
+        if (m.index === crt_regex.lastIndex) {
+          crt_regex.lastIndex++;
+        }
+        config.pr.client_crt.push(m[1].replace(/\n/g, ""));
+      }
+    } else {
+      config.pr.client_crt = [config.pr.client_crt.replace(/\n/g, "")];
+    }
+  }
+};
+
+exports.create_jwt = async function create_jwt(payload) {
+  // Prepare our private key to be able to create JWSs
+  await ensure_client_key_is_ready();
+
+  return await jose.JWS.createSign({
+    algorithm: 'RS256',
+    format: 'compact',
+    fields: {
+      typ: "JWT",
+      x5c: config.pr.client_crt
+    }
+  }, config.pr.client_key).update(JSON.stringify(payload)).final();
+};

--- a/controllers/web/users.js
+++ b/controllers/web/users.js
@@ -263,6 +263,7 @@ exports.edit = function (req, res) {
   } else {
     req.user.image_gravatar = gravatar.url(req.session.user.email, { s: 100, r: 'g', d: 404 }, { protocol: 'https' });
     res.render('users/edit', {
+      identity_attributes,
       user: req.user,
       error: [],
       csrf_token: req.csrfToken()

--- a/lib/configService.js
+++ b/lib/configService.js
@@ -464,12 +464,12 @@ function process_environment_variables(verbose) {
   }
   if (process.env.IDM_AR_TOKEN_ENDPOINT) {
     config.ar.token_endpoint = process.env.IDM_AR_TOKEN_ENDPOINT;
-  } else if (config.ar.url != null && config.ar.url != "internal" && config.ar.token_endpoint == null) {
+  } else if (config.ar.url != null && config.ar.url !== "internal" && config.ar.token_endpoint == null) {
     config.ar.token_endpoint = (new URL('connect/token', config.ar.url)).toString();
   }
   if (process.env.IDM_AR_DELEGATION_ENDPOINT) {
     config.ar.delegation_endpoint = process.env.IDM_AR_DELEGATION_ENDPOINT;
-  } else if (config.ar.url != null && config.ar.url != "internal" && config.ar.delegation_endpoint == null) {
+  } else if (config.ar.url != null && config.ar.url !== "internal" && config.ar.delegation_endpoint == null) {
     config.ar.delegation_endpoint = (new URL('delegation', config.ar.url)).toString();
   }
 

--- a/lib/configService.js
+++ b/lib/configService.js
@@ -464,12 +464,12 @@ function process_environment_variables(verbose) {
   }
   if (process.env.IDM_AR_TOKEN_ENDPOINT) {
     config.ar.token_endpoint = process.env.IDM_AR_TOKEN_ENDPOINT;
-  } else if (config.ar.url != null && config.ar.token_endpoint == null) {
+  } else if (config.ar.url != null && config.ar.url != "internal" && config.ar.token_endpoint == null) {
     config.ar.token_endpoint = (new URL('connect/token', config.ar.url)).toString();
   }
   if (process.env.IDM_AR_DELEGATION_ENDPOINT) {
     config.ar.delegation_endpoint = process.env.IDM_AR_DELEGATION_ENDPOINT;
-  } else if (config.ar.url != null && config.ar.delegation_endpoint == null) {
+  } else if (config.ar.url != null && config.ar.url != "internal" && config.ar.delegation_endpoint == null) {
     config.ar.delegation_endpoint = (new URL('delegation', config.ar.url)).toString();
   }
 

--- a/migrations/20210607162019-CreateDelegationEvidenceTable.js
+++ b/migrations/20210607162019-CreateDelegationEvidenceTable.js
@@ -6,17 +6,17 @@ module.exports = {
       'delegation_evidence',
       {
         policy_issuer: {
-          type: DataTypes.STRING,
+          type: Sequelize.STRING,
           allowNull: false,
           primaryKey: true
         },
         access_subject: {
-          type: DataTypes.STRING,
+          type: Sequelize.STRING,
           allowNull: false,
           primaryKey: true
         },
         policy: {
-          type: DataTypes.JSON,
+          type: Sequelize.JSON,
           allowNull: false
         }
       },
@@ -33,6 +33,6 @@ module.exports = {
   },
 
   down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable('users');
+    return queryInterface.dropTable('delegation_evidence');
   }
 };

--- a/migrations/20210607162019-CreateDelegationEvidenceTable.js
+++ b/migrations/20210607162019-CreateDelegationEvidenceTable.js
@@ -1,0 +1,38 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable(
+      'delegation_evidence',
+      {
+        policy_issuer: {
+          type: DataTypes.STRING,
+          allowNull: false,
+          primaryKey: true
+        },
+        access_subject: {
+          type: DataTypes.STRING,
+          allowNull: false,
+          primaryKey: true
+        },
+        policy: {
+          type: DataTypes.JSON,
+          allowNull: false
+        }
+      },
+      {
+        uniqueKeys: {
+          policy_issuer_access_subject_unique: {
+            customIndex: true,
+            fields: ['policy_issuer', 'access_subject'],
+          }
+        },
+        sync: { force: true }
+      }
+    );
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('users');
+  }
+};

--- a/models/delegation_evidence.js
+++ b/models/delegation_evidence.js
@@ -1,0 +1,37 @@
+// BD to store all Auth Tokens
+
+module.exports = function (sequelize, DataTypes) {
+  const DelegationEvidence = sequelize.define(
+    'DelegationEvidence',
+    {
+      policy_issuer: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        primaryKey: true
+      },
+      access_subject: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        primaryKey: true
+      },
+      policy: {
+        type: DataTypes.JSON,
+        allowNull: false
+      }
+    },
+    {
+      indexes: [
+        {
+          unique: true,
+          fields: [ 'policy_issuer', 'access_subject' ]
+        }
+      ],
+      tableName: 'delegation_evidence',
+      timestamps: false,
+      underscored: true
+    }
+  );
+
+  return DelegationEvidence;
+};
+

--- a/models/model_oauth_server.js
+++ b/models/model_oauth_server.js
@@ -919,13 +919,6 @@ function generateIdToken(client, user, nonce) {
       idToken['exp'] = Math.round(Date.now() / 1000) + config_oauth2.access_token_lifetime;
       idToken['iat'] = Math.round(Date.now() / 1000);
       idToken['nonce'] = nonce;
-      if (config.ar != null && config.ar.url != null) {
-        idToken['authorisationRegistry'] = {
-          url: config.ar.url,
-          token_endpoint: config.ar.token_endpoint,
-          delegation_endpoint: config.ar.delegation_endpoint
-        };
-      }
       return idToken;
     })
     .catch(function (error) {

--- a/models/models.js
+++ b/models/models.js
@@ -120,6 +120,9 @@ const role_usage_policy = sequelize.import(path.join(__dirname, 'role_usage_poli
 // Import ptp table
 const ptp = sequelize.import(path.join(__dirname, 'ptp'));
 
+// Import delegation evidence table
+const delegation_evidence = sequelize.import(path.join(__dirname, 'delegation_evidence'));
+
 // Relation between oauth_client and trusted applications
 trusted_application.belongsTo(oauth_client, { onDelete: 'cascade' });
 trusted_application.belongsTo(oauth_client, {
@@ -304,6 +307,7 @@ exports.trusted_application = trusted_application;
 exports.usage_policy = usage_policy;
 exports.role_usage_policy = role_usage_policy;
 exports.ptp = ptp;
+exports.delegation_evidence = delegation_evidence;
 
 // Export helpers
 const search_identity = require('./helpers/search_identity');

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "test:coverage": "nyc --reporter=lcov mocha -- 'test/integration/*.js' 'test/integration/**/*.js' --timeout 3000 --ui bdd --exit",
     "test:coveralls": "npm run test:coverage && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
     "test:single": "DEBUG=idm:*,oauth2-server:* mocha",
-    "test:watch": "npm run test -- -w ./lib"
+    "test:watch": "npm run test -- -w ./lib",
+    "unittest": "nyc --reporter=text mocha -- 'test/unit/*.js' 'test/unit/**/*.js' --reporter spec --timeout 3000 --ui bdd --exit",
+    "unittest:coverage": "nyc --reporter=lcov mocha -- 'test/unit/*.js' 'test/unit/**/*.js' --reporter spec --timeout 3000 --ui bdd --exit"
   },
   "dependencies": {
     "async": "^2.6.0",

--- a/routes/authregistry/authregistry.js
+++ b/routes/authregistry/authregistry.js
@@ -1,0 +1,44 @@
+const express = require('express');
+const router = express.Router();
+const debug = require('debug')('idm:authregistry_model');
+
+const authregistry_controller = require('../../controllers/authregistry/authregistry');
+
+// Routes for the Authorization Registry module
+router.post(
+  '/policy',
+  authregistry_controller.upsert_policy
+)
+router.post(
+  '/delegation',
+  authregistry_controller.query_evidences
+);
+
+// catch 404 and forward to error handler
+router.use((req, res) => {
+  const err = new Error('Path not Found');
+
+  err.status = 404;
+  if (req.useragent.isDesktop) {
+    res.locals.error = err;
+    res.render('errors/not_found');
+  } else {
+    res.status(404).json(err.message);
+  }
+});
+
+// Error handler
+/* eslint-disable no-unused-vars */
+router.use((err, req, res, next) => {
+  /* eslint-enable no-unused-vars */
+  debug(err);
+
+  err.status = err.status || 500;
+  // set locals, only providing error in development
+  res.locals.error = req.app.get('env') === 'development' ? err : {};
+  // render the error page
+  res.status(err.status);
+  res.render('errors/authregistry');
+});
+
+module.exports = router;

--- a/test/unit/authregistry.js
+++ b/test/unit/authregistry.js
@@ -1,0 +1,385 @@
+/* eslint-env mocha */
+/* eslint-disable snakecase/snakecase */
+
+const sinon = require("sinon");
+
+// Load test configuration
+const config_service = require('../../lib/configService.js');
+config_service.set_config(require('../config-test'));
+const config = config_service.get_config();
+
+const models = require('../../models/models.js');
+const authregistry = require("../../controllers/authregistry/authregistry");
+const utils = require("../../controllers/extparticipant/utils");
+
+
+const USER1 = {
+  user: {
+    id: "930439c2-4259-4da3-be65-ea12b75aa425",
+    username: "aarranz",
+    admin: true
+  }
+};
+Object.freeze(USER1);
+
+const DELEGATION_MASK1 = {
+  delegationRequest: {
+    policyIssuer: "EU.EORI.NLHAPPYPETS",
+    target: {
+      accessSubject: "1b49be31-ecd4-4a52-8a99-502ba8f24ecc"
+    },
+    policySets: [{
+      policies: [{
+        target: {
+          resource: {
+            type: "GS1.CONTAINER",
+            identifiers: ["180621.ABC1234"],
+            attributes: ["GS1.CONTAINER.ATTRIBUTE.ETA"]
+          },
+          actions: ["ISHARE.READ"],
+          environment: {
+            serviceProviders: ["EU.EORI.NL000000003"]
+          }
+        },
+        rules: [
+          {
+            effect: "Permit"
+          }
+        ]
+      }]
+    }]
+  }
+};
+Object.freeze(DELEGATION_MASK1);
+
+const DELEGATION_MASK2 = {
+  delegationRequest: {
+    policyIssuer: "EU.EORI.NLHAPPYPETS",
+    target: {
+      accessSubject: "1b49be31-ecd4-4a52-8a99-502ba8f24ecc"
+    },
+    policySets: [{
+      policies: [{
+        target: {
+          resource: {
+            type: "DELIVERYORDER",
+            identifiers: ["180621.ABC1234"],
+            attributes: ["ETA"]
+          },
+          actions: ["GET"]
+        },
+        rules: [
+          {
+            effect: "Permit"
+          }
+        ]
+      }]
+    }]
+  }
+};
+Object.freeze(DELEGATION_MASK2);
+
+const DELEGATION_EVIDENCE1 = {
+  notBefore: 1541058939,
+  notOnOrAfter: 2147483647,
+  policyIssuer: "EU.EORI.NLHAPPYPETS",
+  target: {
+    accessSubject: "1b49be31-ecd4-4a52-8a99-502ba8f24ecc"
+  },
+  policySets: [
+    {
+      maxDelegationDepth: 1,
+      target: {
+        environment: {
+          licenses: ["ISHARE.0001"]
+        }
+      },
+      policies: [
+        {
+          target: {
+            resource: {
+              type: "DELIVERYORDER",
+              identifiers: ["*"],
+              attributes: ["*"]
+            },
+            actions: ["GET"]
+          },
+          rules: [{
+            effect: "Permit"
+          }]
+        }
+      ]
+    }
+  ]
+};
+
+const build_mocks = function build_mocks() {
+  const req = {
+    headers: {
+      authorization: "Bearer invalid"
+    },
+    method: "POST",
+    query: "",
+    body: {}
+  };
+  const res = {
+    locals: {},
+    render: sinon.spy(),
+    json: sinon.spy(),
+    end: sinon.spy()
+  };
+  res.status = sinon.stub().returns(res);
+  const next = sinon.spy();
+
+  return [req, res, next];
+};
+
+describe('Authorization Registry: ', () => {
+
+  before(() => {
+    config.pr = {
+      client_id: "EU.EORI.NLHAPPYPETS"
+    };
+    config.ar = {
+      url: "internal"
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('upsert_policy', () => {
+
+    it('should report internal errors', (done) => {
+      const [req, res, next] = build_mocks();
+      const error = new Error();
+      sinon.stub(authregistry.oauth2, "authenticate").returns(Promise.reject(error));
+
+      authregistry.upsert_policy(req, res, next);
+
+      // query_evidences is asynchronous so wait request is processed
+      setTimeout(() => {
+        sinon.assert.calledOnce(res.status);
+        sinon.assert.calledWith(res.status, 500);
+        sinon.assert.calledOnce(res.json);
+        sinon.assert.notCalled(next);
+        done();
+      });
+    });
+
+    it('should complain about invalid auth token', (done) => {
+      const [req, res, next] = build_mocks();
+      const error = new authregistry.oauth2.constructor.UnauthorizedRequestError();
+      sinon.stub(authregistry.oauth2, "authenticate").returns(Promise.reject(error));
+
+      authregistry.upsert_policy(req, res, next);
+
+      // query_evidences is asynchronous so wait request is processed
+      setTimeout(() => {
+        res.status.calledOnceWithExactly(401);
+        sinon.assert.notCalled(next);
+        done();
+      });
+    });
+
+    it('should complain about invalid policy payloads', (done) => {
+      const [req, res, next] = build_mocks();
+      sinon.stub(authregistry.oauth2, "authenticate").returns(Promise.resolve(USER1));
+
+      authregistry.upsert_policy(req, res, next);
+
+      // query_evidences is asynchronous so wait request is processed
+      setTimeout(() => {
+        sinon.assert.calledOnce(res.status);
+        sinon.assert.calledWith(res.status, 400);
+        sinon.assert.notCalled(next);
+        done();
+      });
+    });
+
+    it('should store new delegation evidences', (done) => {
+      const [req, res, next] = build_mocks();
+      req.body = {
+        delegationEvidence: DELEGATION_EVIDENCE1
+      };
+      sinon.stub(models.user, "findOne").returns(Promise.resolve(USER1));
+      sinon.stub(models.delegation_evidence, "upsert");
+      sinon.stub(authregistry.oauth2, "authenticate").returns(Promise.resolve(USER1));
+
+      authregistry.upsert_policy(req, res, next);
+
+      // query_evidences is asynchronous so wait request is processed
+      setTimeout(() => {
+        sinon.assert.calledOnce(models.delegation_evidence.upsert);
+        sinon.assert.calledOnce(res.status);
+        sinon.assert.calledWith(res.status, 200);
+        sinon.assert.calledOnce(next);
+        done();
+      });
+    });
+
+  });
+
+  describe('query_evidences', () => {
+
+    it('should report internal errors', (done) => {
+      const [req, res, next] = build_mocks();
+      const error = new Error();
+      sinon.stub(authregistry.oauth2, "authenticate").returns(Promise.reject(error));
+
+      authregistry.query_evidences(req, res, next);
+
+      // query_evidences is asynchronous so wait request is processed
+      setTimeout(() => {
+        sinon.assert.calledOnce(res.status);
+        sinon.assert.calledWith(res.status, 500);
+        sinon.assert.calledOnce(res.json);
+        sinon.assert.notCalled(next);
+        done();
+      });
+    });
+
+    it('should complain about invalid auth token', (done) => {
+      const [req, res, next] = build_mocks();
+      const error = new authregistry.oauth2.constructor.UnauthorizedRequestError();
+      sinon.stub(authregistry.oauth2, "authenticate").returns(Promise.reject(error));
+
+      authregistry.query_evidences(req, res, next);
+
+      // query_evidences is asynchronous so wait request is processed
+      setTimeout(() => {
+        sinon.assert.calledOnce(res.status);
+        sinon.assert.calledWith(res.status, 401);
+        sinon.assert.notCalled(next);
+        done();
+      });
+    });
+
+    it('should complain about invalid delegation payloads', (done) => {
+      const [req, res, next] = build_mocks();
+      sinon.stub(authregistry.oauth2, "authenticate").returns(Promise.resolve(USER1));
+
+      authregistry.query_evidences(req, res, next);
+
+      // query_evidences is asynchronous so wait request is processed
+      setTimeout(() => {
+        sinon.assert.calledOnce(res.status);
+        sinon.assert.calledWith(res.status, 400);
+        sinon.assert.notCalled(next);
+        done();
+      });
+    });
+
+    it('should return 404 if there is not delegation evidence', (done) => {
+      const [req, res, next] = build_mocks();
+      req.body = DELEGATION_MASK1;
+      sinon.stub(models.delegation_evidence, "findOne").returns(null);
+      sinon.stub(authregistry.oauth2, "authenticate").returns(Promise.resolve(USER1));
+
+      authregistry.query_evidences(req, res, next);
+
+      // query_evidences is asynchronous so wait request is processed
+      setTimeout(() => {
+        sinon.assert.calledOnce(res.status);
+        sinon.assert.calledWith(res.status, 404);
+        sinon.assert.notCalled(next);
+        done();
+      });
+    });
+
+    it('should return delegation evidences when there are not matching policies', (done) => {
+      const [req, res, next] = build_mocks();
+      req.body = DELEGATION_MASK1;
+      sinon.stub(models.delegation_evidence, "findOne").returns({
+          policy: JSON.parse(JSON.stringify(DELEGATION_EVIDENCE1))
+      });
+      sinon.stub(authregistry.oauth2, "authenticate").returns(Promise.resolve(USER1));
+      sinon.stub(utils, "create_jwt").returns(Promise.resolve("generated_jwt"));
+
+      authregistry.query_evidences(req, res, next);
+
+      // query_evidences is asynchronous so wait request is processed
+      setTimeout(() => {
+        sinon.assert.calledOnce(res.status);
+        sinon.assert.calledWith(res.status, 200);
+        sinon.assert.calledOnce(next);
+        sinon.assert.calledWith(utils.create_jwt, {
+          notBefore: 1541058939,
+          notOnOrAfter: 2147483647,
+          policyIssuer: "EU.EORI.NLHAPPYPETS",
+          policySets: [{
+            maxDelegationDepth: 1,
+            policies: [{
+              // effect is Deny due no policy match
+              rules: [{ effect: "Deny" }],
+              target: {
+                actions: ["ISHARE.READ"],
+                environment: { serviceProviders: ["EU.EORI.NL000000003"] },
+                resource: {
+                  attributes: ["GS1.CONTAINER.ATTRIBUTE.ETA"],
+                  identifiers: ["180621.ABC1234"],
+                  type: "GS1.CONTAINER"
+                }
+              }
+            }],
+            target: { environment: { licenses: ["ISHARE.0001"] } }
+          }],
+          target: { accessSubject: "1b49be31-ecd4-4a52-8a99-502ba8f24ecc" }
+        });
+        sinon.assert.calledOnce(res.json);
+        sinon.assert.calledWith(res.json, {
+          delegation_token: "generated_jwt"
+        });
+        done();
+      });
+    });
+
+    it('should return delegation evidences when there are matching policies', (done) => {
+      const [req, res, next] = build_mocks();
+      req.body = DELEGATION_MASK2;
+      sinon.stub(models.delegation_evidence, "findOne").returns({
+          policy: JSON.parse(JSON.stringify(DELEGATION_EVIDENCE1))
+      });
+      sinon.stub(authregistry.oauth2, "authenticate").returns(Promise.resolve(USER1));
+      sinon.stub(utils, "create_jwt").returns(Promise.resolve("generated_jwt"));
+
+      authregistry.query_evidences(req, res, next);
+
+      // query_evidences is asynchronous so wait request is processed
+      setTimeout(() => {
+        sinon.assert.calledOnce(res.status);
+        sinon.assert.calledWith(res.status, 200);
+        sinon.assert.calledOnce(next);
+        sinon.assert.calledWith(utils.create_jwt, {
+          notBefore: 1541058939,
+          notOnOrAfter: 2147483647,
+          policyIssuer: "EU.EORI.NLHAPPYPETS",
+          policySets: [{
+            maxDelegationDepth: 1,
+            policies: [{
+              rules: [{ effect: "Permit" }],
+              target: {
+                actions: ["GET"],
+                resource: {
+                  attributes: ["ETA"],
+                  identifiers: ["180621.ABC1234"],
+                  type: "DELIVERYORDER"
+                }
+              }
+            }],
+            target: { environment: { licenses: ["ISHARE.0001"] } }
+          }],
+          target: { accessSubject: "1b49be31-ecd4-4a52-8a99-502ba8f24ecc" }
+        });
+        sinon.assert.calledOnce(res.json);
+        sinon.assert.calledWith(res.json, {
+          delegation_token: "generated_jwt"
+        });
+        done();
+      });
+    });
+
+  });
+
+});


### PR DESCRIPTION
## Proposed changes

The main part of this PR is implementing experimental support for having an internal authorization registry. This PR also makes some improvements into the external participant code to also support client_credentials flow and client_assertion_type jwt-bearer. 

## Types of changes

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality
        to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

-   [x] I have read the
        [CONTRIBUTING](https://github.com/ging/fiware-idm/blob/master/CONTRIBUTING.md)
        doc
-   [x] I have signed the
        [CLA](https://github.com/ging/fiware-idm/blob/master/keyrock-individual-cla.pdf)
-   [x] I have added tests that prove my fix is effective or that my feature
        works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream
        modules

## Further comments

Continuation of PR #206 