### PR TITLE
Fix Resource Owner Password Credentials Grant not working

### DIFF
--- a/controllers/api/authenticate.js
+++ b/controllers/api/authenticate.js
@@ -101,7 +101,7 @@ const delete_token = function (req, res) {
       return token.destroy();
     })
     .then(function () {
-      res.status(204).json('Appication ' + req.params.application_id + ' destroyed');
+      res.status(204).json('Application ' + req.params.application_id + ' destroyed');
     })
     .catch(function (error) {
       debug('Error: ' + error);
@@ -362,7 +362,7 @@ const create_token = function (req, res) {
     })
     .catch(function (error) {
       // Log the actual error to the debug log
-      debug('Error: ' + error);
+      debug('Error: ', error);
       // If an actual 401 has been raised, use the existing message.
       // But always return a 401 - Unauthorized error to the user.
       // This avoid information leakage.
@@ -382,10 +382,17 @@ const create_token = function (req, res) {
 // Function to check if parameters exist in request
 function check_create_token_request(req) {
   return new Promise(function (resolve, reject) {
-    if (!req.headers['content-type'] || !req.headers['content-type'].startsWith('application/json')) {
+    if (
+      !req.headers['content-type'] ||
+      !(
+        req.headers['content-type'].startsWith('application/json') ||
+        req.headers['content-type'].startsWith('application/x-www-form-urlencoded')
+      )
+    ) {
       reject({
         error: {
-          message: 'Missing parameter: header Content-Type: application/json',
+          message:
+            'Missing parameter: header Content-Type: application/json or header Content-Type: application/x-www-form-urlencoded',
           code: 400,
           title: 'Bad Request'
         }

--- a/test/integration/api/000-authenticate.js
+++ b/test/integration/api/000-authenticate.js
@@ -115,4 +115,27 @@ describe('API - 0 - Authenticate: ', function () {
       });
     });
   });
+
+  describe('5) When Logging in with a valid username and password', function () {
+    const good_login = {
+      url: config.host + '/v1/auth/tokens',
+      method: 'POST',
+      form: {
+        grant_type: 'password',
+        name: login.good_login.name,
+        password: login.good_login.password
+      },
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded'
+      }
+    };
+
+    it('should return a 201 OK', function (done) {
+      request(good_login, function (error, response) {
+        should.not.exist(error);
+        response.statusCode.should.equal(201);
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Proposed changes

I noticed that the Resource Owner Password Credentials Grant as described in the doc is not working.
However, there are a couple of problems:.

According to the [RFC](https://datatracker.ietf.org/doc/html/rfc6749#section-4.3.2) the body parameter should be `username`
Currently, it's only working with `name`. I wanted to avoid breaking the [existing API](https://keyrock.docs.apiary.io/#reference/keyrock-api/authentication/create-token-with-password-method) because both variants use the same methods.
I leave the decision to you


## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in
the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing functionality
        to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

-   [ ] I have read the
        [CONTRIBUTING](https://github.com/ging/fiware-idm/blob/master/CONTRIBUTING.md)
        doc
-   [ ] I have signed the
        [CLA](https://github.com/ging/fiware-idm/blob/master/keyrock-individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature
        works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream
        modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
