### PR TITLE
Fix #196 - Dynamically update release version and release_date

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,6 +14,17 @@ const partials = require('express-partials');
 const path = require('path');
 const sass_middleware = require('node-sass-middleware');
 const session = require('cookie-session');
+const packageInformation = require('./package.json');
+const fs = require('fs')
+
+const version = require('./version.json');
+version.keyrock.version = packageInformation.version;
+version.keyrock.doc =  packageInformation.homepage;
+
+fs.stat("./package.json", function(err, stats){
+   version.keyrock.release_date = stats.mtime;
+
+});
 
 // Obtain secret from config file
 const config_service = require('./lib/configService.js');
@@ -97,7 +108,6 @@ if (config.cors.enabled) {
 // Set routes for version
 const up_date = new Date();
 app.use('/version', function (req, res) {
-  const version = require('./version.json');
   version.keyrock.uptime = require('./lib/time').ms_to_time(new Date() - up_date);
   version.keyrock.api.link = config.host + '/' + version.keyrock.api.version;
   res.status(200).send(version);

--- a/app.js
+++ b/app.js
@@ -14,12 +14,12 @@ const partials = require('express-partials');
 const path = require('path');
 const sass_middleware = require('node-sass-middleware');
 const session = require('cookie-session');
-const packageInformation = require('./package.json');
+const package_info = require('./package.json');
 const fs = require('fs')
 
 const version = require('./version.json');
-version.keyrock.version = packageInformation.version;
-version.keyrock.doc =  packageInformation.homepage;
+version.keyrock.version = package_info.version;
+version.keyrock.doc =  package_info.homepage;
 
 fs.stat("./package.json", function(err, stats){
    version.keyrock.release_date = stats.mtime;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,14 @@
 {
   "name": "fiware-idm",
   "version": "8.1.0",
+  "homepage": "https://keyrock-fiware.github.io/",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/ging/fiware-idm.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ging/fiware-idm/issues"
+  },
   "private": true,
   "license": "MIT",
   "scripts": {

--- a/version.json
+++ b/version.json
@@ -1,10 +1,9 @@
 {
 	"keyrock": {
-		"version": "7.0.1",
-		"release_date": "2018-06-25",
+		"version": "",
+		"release_date": "",
 		"uptime": "",
-		"git_hash": "https://github.com/ging/fiware-idm/releases/tag/7.0.1",
-		"doc": "https://fiware-idm.readthedocs.io/en/7.0.1/",
+		"doc": "https://keyrock-fiware.github.io/",
 		"api": {
 			"version": "v1",
 			"link": ""


### PR DESCRIPTION
## Proposed changes

As issue #196 describes, the `version.json` file has not been maintained since 7.0.1. This PR updates the endpoint to receive values from `package.json` instead. Standard npm `homepage`, `repository` and `bugs` values have been added to the `package.json` as well.

Standard commands like `npm docs` and `npm bugs` now work as expected.


## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in
the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality
        to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

-   [x] I have read the
        [CONTRIBUTING](https://github.com/ging/fiware-idm/blob/master/CONTRIBUTING.md)
        doc
-   [x] I have signed the
        [CLA](https://github.com/ging/fiware-idm/blob/master/keyrock-individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature
        works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream
        modules