### PR TITLE
Improve scope management

### DIFF
--- a/controllers/extparticipant/extparticipant.js
+++ b/controllers/extparticipant/extparticipant.js
@@ -370,7 +370,7 @@ async function _token(req, res) {
     code.save();
 
     // Build id and access tokens
-    scopes = new Set(code.scope);
+    scopes = new Set(code.scope.split(/[,\s]+/));
     client = code.OauthClient;
     user = code.User;
     id_token = await build_id_token(client, user, scopes, code.nonce, code.extra.iat);
@@ -392,7 +392,7 @@ async function _token(req, res) {
     });
     user = await models.user.findOne({where: {username: client_payload.iss}});
     // Build id and access tokens
-    scopes = new Set(req.body.scope != null ? req.body.scope.split(' ') : []);
+    scopes = new Set(req.body.scope != null ? req.body.scope.split(/[,\s]+/) : []);
     id_token = await build_id_token(client, user, scopes);
   }
 

--- a/models/model_oauth_server.js
+++ b/models/model_oauth_server.js
@@ -856,21 +856,9 @@ function app_authzforce_domain(app_id) {
 function validateScope(user, client, scope) {
   debug('-------validateScope-------');
 
-  if (scope && scope.length > 0) {
-    let requested_scopes;
-    if (typeof scope === 'string' && scope.includes(',')) {
-      requested_scopes = scope.split(',');
-    } else if (typeof scope === 'object') {
-      requested_scopes = scope[0].split(',');
-    } else if (typeof scope === 'string' && scope.includes(' ')) {
-      requested_scopes = scope;
-    } else if (typeof scope === 'object') {
-      requested_scopes = scope[0];
-    } else {
-      requested_scopes = scope;
-    }
+  if (typeof scope === "string" && scope.length > 0) {
+    const requested_scopes = scope.split(/[,\s]+/);
 
-    //let requested_scopes = typeof scope === 'string' ? scope.split(',') : scope[0].split(',');
     if (requested_scopes.includes('bearer') && requested_scopes.includes('jwt')) {
       return false;
     }

--- a/test/unit/model_oauth_server.js
+++ b/test/unit/model_oauth_server.js
@@ -1,0 +1,82 @@
+/* eslint-env mocha */
+
+const should = require('should');
+const sinon = require("sinon");
+
+// Load test configuration
+const config_service = require('../../lib/configService.js');
+config_service.set_config(require('../config-test'));
+const config = config_service.get_config();
+
+const model_oauth_server = require('../../models/model_oauth_server.js');
+
+describe('OAuth Server: ', () => {
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('validateScope(user, client, scope)', () => {
+
+    describe('should return bearer scope', () => {
+      const test = (label, value) => {
+        it(`when providing ${label} as scope`, () => {
+          const result = model_oauth_server.validateScope(null, null, value);
+          result.should.be.eql(['bearer']);
+        });
+      };
+
+      test('null', null);
+      test('""', "");
+      test('[]', []);
+    })
+
+    describe('should return false', () => {
+      const test = (label, value, client) => {
+        it(label, () => {
+          const result = model_oauth_server.validateScope(null, client, value);
+          result.should.be.eql(false);
+        });
+      };
+
+      test('when using bearer and jwt scopes at the same time (comma-separated string)', "bearer,jwt");
+      test('when using bearer and jwt scopes at the same time (comma-separated string, extra scopes)', "openid,bearer,jwt,profile");
+      test('when using bearer and jwt scopes at the same time (whitespace-separated string)', "bearer jwt");
+      test('when using bearer and jwt scopes at the same time (whitespace-separated string, extra scopes)', "openid bearer jwt profile");
+
+      // Permanent tokens not enabled 
+      test('when using permanent scope on a client not supporting permanent tokens', "permanent", {token_types: ["bearer"]});
+      test('when using permanent scope on a client not supporting permanent tokens (comma-separated string, extra scopes)', "openid,permanent,jwt", {token_types: ["bearer"]});
+      test('when using permanent scope on a client not supporting permanent tokens (whitespace-separated string, extra scopes)', "openid permanent bearer", {token_types: ["bearer"]});
+
+      // JWT tokens not enabled
+      test('when using jwt scope on a client not supporting jwt tokens', "jwt", {token_types: ["bearer"]});
+      test('when using jwt scope on a client not supporting jwt tokens (comma-separated string, extra scopes)', "openid,jwt,profile", {token_types: ["bearer"]});
+      test('when using jwt scope on a client not supporting jwt tokens (whitespace-separated string, extra scopes)', "openid jwt profile", {token_types: ["bearer"]});
+
+      // OpenID Connect tokens not enabled
+      test('when using openid scope on a client not supporting openid tokens', "openid", {scope: []});
+      test('when using openid scope on a client not supporting openid tokens (comma-separated string, extra scopes)', "email,openid,profile", {scope: []});
+      test('when using openid scope on a client not supporting openid tokens (whitespace-separated string, extra scopes)', "email openid profile", {scope: []});
+    })
+
+    describe('should return the provided scopes if they are valid', () => {
+      const test = (label, value, client, expected) => {
+        it(`when providing ${label} as scope`, () => {
+          const result = model_oauth_server.validateScope(null, client, value);
+          result.should.be.eql(expected);
+        });
+      };
+
+      test('basic permanent token', 'permanent', {token_types: ["permanent"]}, ["permanent"]);
+      test('basic jwt token', 'jwt', {token_types: ["jwt"]}, ["jwt"]);
+      test('basic openid token', 'openid', {scope: ["openid"]}, ["openid"]);
+      test('openid + jwt', 'openid jwt', {scope: ["openid"], token_types: ["jwt"]}, ["openid", "jwt"]);
+      test('openid + permanent', 'openid permanent', {scope: ["openid"], token_types: ["permanent"]}, ["openid", "permanent"]);
+      test('openid + permanent + jwt', 'openid permanent jwt', {scope: ["openid"], token_types: ["jwt", "permanent"]}, ["openid", "permanent", "jwt"]);
+      test('openid + profile', 'openid profile', {scope: ["openid"]}, ["openid", "profile"]);
+    })
+
+  });
+
+});

--- a/test/unit/model_oauth_server.js
+++ b/test/unit/model_oauth_server.js
@@ -1,18 +1,17 @@
 /* eslint-env mocha */
 
-const should = require('should');
+require('should');
 const sinon = require("sinon");
 
 // Load test configuration
 const config_service = require('../../lib/configService.js');
 config_service.set_config(require('../config-test'));
-const config = config_service.get_config();
 
 const model_oauth_server = require('../../models/model_oauth_server.js');
 
 describe('OAuth Server: ', () => {
 
-  afterEach(() => {
+  afterEach(() => {  // eslint-disable-line snakecase/snakecase
     sinon.restore();
   });
 


### PR DESCRIPTION
## Proposed changes

This PR updates the `validateScope` method to allow providing a space-separated list of scopes (in addition to support current comma-separated behaviour). This PR also adds unit tests.

## Types of changes

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality
        to not work as expected)

## Checklist

-   [x] I have read the
        [CONTRIBUTING](https://github.com/ging/fiware-idm/blob/master/CONTRIBUTING.md)
        doc
-   [x] I have signed the
        [CLA](https://github.com/ging/fiware-idm/blob/master/keyrock-individual-cla.pdf)
-   [x] I have added tests that prove my fix is effective or that my feature
        works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream
        modules

## Further comments

OAuth2/Open ID Connect services use space-separated lists of scopes by default, so this should make standard clients happier and allow to use more libraries for connecting to KeyRock. In any case, the default comma-separated behaviour should be maintained and ensured due to the new unit tests.

Now that KeyRock uses a custom implementation of `oauth-server`, the implementation can be simplified avoiding to tests if the `scope` parameter is an argument array or just the scope string (I think that this requirement is meet just at current version but please, confirm if possible).