### PR TITLE
Customizable Authorization Page

### DIFF
--- a/etc/translations/de.json
+++ b/etc/translations/de.json
@@ -914,7 +914,7 @@
       "authorize": {
         "title": "Autorisieren",
         "content01": "Die Anwendung",
-        "content02": "wird in der Lage sein:",
+        "content02": "wird autorisiert sein:",
         "content03": "Lesen Sie Ihre öffentlichen Informationen.",
         "deny_btn": "Ablehnen",
         "authorize_btn": "Autorisieren"

--- a/views/oauth/_authorize.ejs
+++ b/views/oauth/_authorize.ejs
@@ -1,0 +1,49 @@
+<div id="authorize_application_modal" class="static_page">
+  <div class="">
+    <div class="">
+      <div class="modal-header">
+        <h3>
+          <%=translation.oauth.authorize.title%>
+            <%= application.name %>?
+        </h3>
+      </div>
+      <form id="" ng-controller="DummyCtrl" name="" autocomplete="" class="ng-scope ng-pristine ng-valid"
+        action="<%= application.url %>" method="POST" enctype="">
+        <input type='hidden' name='_csrf' value='<%= csrf_token%>' />
+        <div class="modal-body clearfix">
+          <div>
+            <p>
+              <%=translation.oauth.authorize.content01%> <a href="/idm/applications/<%= application.id %>/">
+                  <%= application.name %>
+                </a> tendrá permisos para acceder a:
+            </p>
+            <div class="select-multiple">
+              <select name="user_authorized_application[shared_attributes]" class="selectpicker"
+                data-dropup-auto="false" multiple>
+                <option value="username" selected>Username</option>
+                <option value="email" selected>Email</option>
+                <option value="identity_attributes" selected>Identity Attributes</option>
+                <option value="image" selected>Image</option>
+                <option value="gravatar" selected>Gravatar</option>
+                <option value="eidas_profile" selected>eIDAS Profile</option>
+              </select>
+            </div>
+            <!-- <div class="alert alert-info">
+                    <%=translation.oauth.authorize.content03%>
+              </div> -->
+          </div>
+          <fieldset>
+          </fieldset>
+        </div>
+        <div class="modal-footer">
+          <a href="/" class="secondary cancel btn btn-default">
+            <%=translation.oauth.authorize.deny_btn%>
+          </a>
+          <button type="submit" class="btn btn-primary">
+            <%=translation.oauth.authorize.authorize_btn%>
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/views/oauth/_authorize.ejs
+++ b/views/oauth/_authorize.ejs
@@ -15,7 +15,7 @@
             <p>
               <%=translation.oauth.authorize.content01%> <a href="/idm/applications/<%= application.id %>/">
                   <%= application.name %>
-                </a> tendrá permisos para acceder a:
+                </a> <%=translation.oauth.authorize.content02%>
             </p>
             <div class="select-multiple">
               <select name="user_authorized_application[shared_attributes]" class="selectpicker"

--- a/views/oauth/authorize.ejs
+++ b/views/oauth/authorize.ejs
@@ -1,40 +1,13 @@
+<%
+  var authorize = '_authorize';
+
+  if (site.theme !== 'default') {
+    if(fs.existsSync('themes/' + site.theme + '/templates/_authorize.ejs')) {
+      authorize = '../../themes/' + site.theme + '/templates/_authorize';
+    }
+  }
+%>
+
 <div id="content_body">
-  <div id="authorize_application_modal" class="static_page">
-    <div class="">
-      <div class="">
-        <div class="modal-header">
-          <h3><%=translation.oauth.authorize.title%> <%= application.name %>?</h3>
-        </div>
-    	<form id="" ng-controller="DummyCtrl" name="" autocomplete="" class="ng-scope ng-pristine ng-valid" action="<%= application.url %>" method="POST" enctype="">
-        <input type='hidden' name='_csrf' value='<%= csrf_token%>' />
-          <div class="modal-body clearfix">
-            <div>
-              <p>
-                <%=translation.oauth.authorize.content01%> <a href="/idm/applications/<%= application.id %>/"><%= application.name %></a> tendrá permisos para acceder a:
-              </p>
-              <div class="select-multiple">
-                  <select name="user_authorized_application[shared_attributes]" class="selectpicker" data-dropup-auto="false" multiple>
-                      <option value="username" selected>Username</option>
-                      <option value="email" selected>Email</option>
-                      <option value="identity_attributes" selected>Identity Attributes</option>
-                      <option value="image" selected>Image</option>
-                      <option value="gravatar" selected>Gravatar</option>
-                      <option value="eidas_profile" selected>eIDAS Profile</option>
-                  </select>
-              </div>
-              <!-- <div class="alert alert-info">
-                    <%=translation.oauth.authorize.content03%>
-              </div> -->
-            </div>
-            <fieldset>
-            </fieldset>
-          </div>
-          <div class="modal-footer">
-            <a href="/" class="secondary cancel btn btn-default"><%=translation.oauth.authorize.deny_btn%></a>
-            <button type="submit" class="btn btn-primary"><%=translation.oauth.authorize.authorize_btn%></button>
-          </div>
-        </form>
-      </div>
-    </div>
-  </div>
+  <%- include(authorize) %>  
 </div>


### PR DESCRIPTION
## Proposed changes

This PR adds the possibility to change the authorization page `views/oauth/authorize.ejs` through a theme by providing the file `themes/<MY_THEME>/templates/_authorize.ejs`

## Types of changes

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality
        to not work as expected)

## Checklist

-   [x] I have read the
        [CONTRIBUTING](https://github.com/ging/fiware-idm/blob/master/CONTRIBUTING.md)
        doc
-   [x] I have signed the
        [CLA](https://github.com/ging/fiware-idm/blob/master/keyrock-individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature
        works
-   [ ] I have added necessary documentation (if appropriate)
-   [x] Any dependent changes have been merged and published in downstream
        modules

## Further comments
