### PR TITLE
Fix hardcoded aud ID value for participant registry

### DIFF
--- a/controllers/extparticipant/utils.js
+++ b/controllers/extparticipant/utils.js
@@ -83,7 +83,7 @@ const retrieve_participant_registry_token = async function retrieve_participant_
     jti: uuid.v4(),
     iss: config.pr.client_id,
     sub: config.pr.client_id,
-    aud: ['EU.EORI.NL000000000', config.pr.token_endpoint],
+    aud: [config.pr.id, config.pr.token_endpoint],
     iat,
     exp
   };


### PR DESCRIPTION
## Proposed changes

There is a bug with the JWT aud parameter when requesting an access token at the participant registry/satellite. 
This was hardcoded with the ID of the iSHARE test instance. This fix changes this parameter to the one from the Keyrock configuration.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in
the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality
        to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

-   [x] I have read the
        [CONTRIBUTING](https://github.com/ging/fiware-idm/blob/master/CONTRIBUTING.md)
        doc
-   [x] I have signed the
        [CLA](https://github.com/ging/fiware-idm/blob/master/keyrock-individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature
        works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream
        modules


