### PR TITLE
Bugfixing for /user endpoint.

### DIFF
--- a/controllers/oauth2/oauth2.js
+++ b/controllers/oauth2/oauth2.js
@@ -480,7 +480,7 @@ exports.authenticate_token = function (req, res) {
       .findByPk(options.application)
       .then(function (application) {
         if (application) {
-          if (application.token_types.includes('jwt')) {
+          if (application.token_types && application.token_types.includes('jwt')) {
             return authenticate_jwt(req, res, options, application.jwt_secret);
           }
           return authenticate_bearer(req, res, options);

--- a/models/model_oauth_server.js
+++ b/models/model_oauth_server.js
@@ -888,7 +888,7 @@ function trusted_applications(app_id) {
 
   return models.trusted_application
     .findAll({
-      where: { oauth_client_id: { [Op.is]: app_id } },
+      where: { oauth_client_id: {app_id} },
       attributes: ['trusted_oauth_client_id']
     })
     .then(function (trusted_apps) {

--- a/models/model_oauth_server.js
+++ b/models/model_oauth_server.js
@@ -886,9 +886,9 @@ function user_permissions(roles_id, app_id, action, resource, options) {
 function trusted_applications(app_id) {
   debug('-------trusted_applications-------');
 
-  return models.trusted_application
+  return app_id ? models.trusted_application
     .findAll({
-      where: { oauth_client_id: {app_id} },
+      where: { oauth_client_id: app_id },
       attributes: ['trusted_oauth_client_id']
     })
     .then(function (trusted_apps) {
@@ -896,7 +896,7 @@ function trusted_applications(app_id) {
         return trusted_apps.map((id) => id.trusted_oauth_client_id);
       }
       return [];
-    });
+    }) : [];
 }
 
 // Search authzforce domain for specific application


### PR DESCRIPTION
-  Add null check
- Remove IS operator
- Add SQL hardening

## Proposed changes

540c3e5bd5 adds an `IS` operator to trusted applications. When firing the PDP with the `/user` end point, with MySQL 8, this results in the following Sequelize error message:

```
You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near'
```

Fix is to remove the `Op.IS` operator since the SQL is not checking `app_id IS NULL` or the invalid `app_id IS 'xxxxxx'`, but should be checking   `app_id = 'xxxxxx'`

Also on `oauth2.js`, the JWT check assumes that the database holds `token_types` and if it is null, the app errors with `Cannot read property 'includes' of undefined`


## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in
the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality
        to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

-   [x] I have read the
        [CONTRIBUTING](https://github.com/ging/fiware-idm/blob/master/CONTRIBUTING.md)
        doc
-   [x] I have signed the
        [CLA](https://github.com/ging/fiware-idm/blob/master/keyrock-individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature
        works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream
        modules

