### PR TITLE
Install openssl package on distro image

### DIFF
--- a/extras/docker/Dockerfile
+++ b/extras/docker/Dockerfile
@@ -206,6 +206,7 @@ ARG GITHUB_ACCOUNT
 ARG GITHUB_REPOSITORY
 ARG NODE_VERSION
 ARG HEADLESS
+ARG PACKAGE_MANAGER
 
 WORKDIR /opt/fiware-idm
 COPY --from=builder /opt/fiware-idm .
@@ -226,7 +227,10 @@ ENV IDM_HEADLESS=$HEADLESS
 
 # hadolint ignore=DL3018
 RUN \
-    if [ "${PACKAGE_MANAGER}" = "apk"  ]; then \
+    if [ "${PACKAGE_MANAGER}" = "apt"  ]; then \
+        apt-get update; \
+        apt-get install -y --no-install-recommends openssl; \
+    elif [ "${PACKAGE_MANAGER}" = "apk"  ]; then \
         apk add --no-cache ca-certificates bash openssl; \
     fi
 


### PR DESCRIPTION

## Proposed changes

Fiware IDM uses openssl to generate application certs.  This currently fails using the default fiware/idm image becuase openssl is not installed. Therefore we need to install it during he distro build stage when using (default) package manager apt.

Solves ging/fiware-idm#314

## Types of changes

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality
        to not work as expected)

## Checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/ging/fiware-idm/blob/master/CONTRIBUTING.md) doc
-   [ ] I have signed the [CLA](https://github.com/ging/fiware-idm/blob/master/keyrock-individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

none