### PR TITLE
Added nonce to ID token

### DIFF
--- a/controllers/extparticipant/extparticipant.js
+++ b/controllers/extparticipant/extparticipant.js
@@ -191,7 +191,7 @@ async function _token(req, res) {
 
     const code = await models.oauth_authorization_code
       .findOne({
-        attributes: ['oauth_client_id', 'redirect_uri', 'expires', 'user_id', 'scope', 'extra'],
+        attributes: ['oauth_client_id', 'redirect_uri', 'expires', 'user_id', 'scope', 'extra', 'nonce'],
         where: { authorization_code: req.body.code, oauth_client_id: client_id, valid: true },
         include: [models.user, models.oauth_client]
       });


### PR DESCRIPTION
## Proposed changes

The iSHARE OIDC flow created ID tokens without a nonce claim. The SELECT statement for getting oauth information from the database missed the 'nonce' attribute. This attribute has now been added.

## Types of changes

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality
        to not work as expected)

## Checklist

-   [x] I have read the
        [CONTRIBUTING](https://github.com/ging/fiware-idm/blob/master/CONTRIBUTING.md)
        doc
-   [x] I have signed the
        [CLA](https://github.com/ging/fiware-idm/blob/master/keyrock-individual-cla.pdf)
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] I have added tests that prove my fix is effective or that my feature
        works
-   [ ] Any dependent changes have been merged and published in downstream
        modules

## Further comments
No further comments
