### PR TITLE
Fixed serviceproviders 500 status

### DIFF
--- a/controllers/authregistry/authregistry.js
+++ b/controllers/authregistry/authregistry.js
@@ -106,7 +106,7 @@ const is_matching_policy = function is_matching_policy(policy_mask, policy) {
 
     const service_providers_mask = policy_mask.target.environment.serviceProviders;
     const service_providers = policy.target.environment.serviceProviders;
-    const all_mask_sp = service_providers_mask.every(sp => service_providers.has(sp));
+    const all_mask_sp = service_providers_mask.every(sp => service_providers.includes(sp));
     if (!all_mask_sp) {
       return false;
     }


### PR DESCRIPTION
## Proposed changes

When using the internal Keyrock authorization registry, it is possible to request whether a subject has the access rights to execute a specific action on a specific resource. Service providers which are allowed to provide services to the subject can also be configured, but querying on this attribute throws an error and returns status code 500 to the user of the api. This PR changes a non-existent method (`has`) to its implemented equivalent (`includes`), such that the code doesn't crash anymore.

## Types of changes

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality
        to not work as expected)

## Checklist

-   [x] I have read the
        [CONTRIBUTING](https://github.com/ging/fiware-idm/blob/master/CONTRIBUTING.md)
        doc
-   [x] I have signed the
        [CLA](https://github.com/ging/fiware-idm/blob/master/keyrock-individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature
        works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream
        modules

## Further comments

Problem can also be seen in this forum post: https://spaces.fundingbox.com/spaces/i4trust-i4trust-helpdesk/648daadfb958a4312734000c
