### PR TITLE
Fix #340 - only bar access_token as header

### DIFF
--- a/controllers/oauth2/oauth2.js
+++ b/controllers/oauth2/oauth2.js
@@ -470,7 +470,7 @@ exports.authenticate_token = function (req, res) {
     access_token: req.query.access_token || header_access_token
   };
 
-  if (options.authzforce && (options.action || options.resource || options.service_header || options.access_token)) {
+  if (options.authzforce && (options.action || options.resource || options.service_header || header_access_token )) {
     const error = {
       message: 'Cannot handle 2 authentications levels at the same time',
       code: 400,


### PR DESCRIPTION


## Proposed changes

Untested change, but this should allow the authzforce location to be queried using 

```console
curl -X GET \ 
  'http://keyrock/user?access_token={{access_token}}&app_id={{app_id}}&authzforce=true'
```

As was possible prior to Keyrock 8.4.0

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in
the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality
        to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

-   [x] I have read the
        [CONTRIBUTING](https://github.com/ging/fiware-idm/blob/master/CONTRIBUTING.md)
        doc
-   [x] I have signed the
        [CLA](https://github.com/ging/fiware-idm/blob/master/keyrock-individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature
        works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream
        modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
