### PR TITLE
Enabled RS256 signature for JWT access tokens

### DIFF
--- a/models/model_oauth_server.js
+++ b/models/model_oauth_server.js
@@ -311,8 +311,21 @@ function generateJwtToken(token, client, identity) {
       if (token.accessTokenExpiresAt) {
         options.expiresIn = config_oauth2.access_token_lifetime;
       }
+	  
+	  // Add the iss claim
+	  response.iss = config.host + '/idm/applications/' + client.id;
 
-      token.accessToken = jsonwebtoken.sign(response, client.jwt_secret, options);
+      // If the default algorithm (HS256) is chosen, client secret is used to sign the JWT.
+      let secretOrPrivateKey = client.jwt_secret;
+      // Otherwise, if RS256 is chosen, retrieve the application private key and use it to sign the JWT.
+      if (config_oidc.jwt_algorithm === 'RS256') {
+        const privateKey = readKeyIdToken(client);
+        options.algorithm = config_oidc.jwt_algorithm;
+        options.keyid = client.id;
+        secretOrPrivateKey = privateKey;
+      }
+
+      token.accessToken = jsonwebtoken.sign(response, secretOrPrivateKey, options);
       return storeToken(token, client, identity, true);
     })
     .catch(function (error) {


### PR DESCRIPTION
## Proposed changes

Modified `generateJwtToken` method in /models/model_oauth_server.js to allow signing the JWT access token with RS256 (asymmetric) algorithm when set through `config.oidc.jwt_algorithm` attribute or `IDM_OIDC_JWT_ALGORITHM` env variable.
This allows for an easier integration with common OAuth 2.0 libraries such as Spring Security OAuth 2.0 Resource Server.

Closes #357 

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in
the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality
        to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

-   [x] I have read the
        [CONTRIBUTING](https://github.com/ging/fiware-idm/blob/master/CONTRIBUTING.md)
        doc
-   [x] I have signed the
        [CLA](https://github.com/ging/fiware-idm/blob/master/keyrock-individual-cla.pdf)
-   [ ] I have added tests that prove my fix is effective or that my feature
        works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream
        modules
